### PR TITLE
Add public-facing profile and character pages

### DIFF
--- a/app/api/public/profiles/[username]/characters/[slug]/route.ts
+++ b/app/api/public/profiles/[username]/characters/[slug]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+import { getPublicCharacter } from "@/lib/public-profiles";
+
+export async function GET(
+  _: Request,
+  context: { params: { username: string; slug: string } }
+) {
+  const { username, slug } = context.params;
+
+  const result = await getPublicCharacter(username, slug);
+
+  if (!result) {
+    return new NextResponse("Character not found", { status: 404 });
+  }
+
+  return NextResponse.json(result);
+}

--- a/app/api/public/profiles/[username]/route.ts
+++ b/app/api/public/profiles/[username]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+import { getPublicProfile } from "@/lib/public-profiles";
+
+export async function GET(
+  _: Request,
+  context: { params: { username: string } }
+) {
+  const { username } = context.params;
+
+  const profile = await getPublicProfile(username);
+
+  if (!profile) {
+    return new NextResponse("Profile not found", { status: 404 });
+  }
+
+  return NextResponse.json(profile);
+}

--- a/app/profile/[username]/[characterSlug]/page.tsx
+++ b/app/profile/[username]/[characterSlug]/page.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { formatGameSystem, getPublicCharacter } from "@/lib/public-profiles";
+
+function FieldList({
+  title,
+  items,
+}: {
+  title: string;
+  items: { name: string; value: string }[];
+}) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-lg font-semibold text-slate-100">{title}</h3>
+      <div className="grid gap-2 md:grid-cols-2">
+        {items.map((item) => (
+          <div
+            key={item.name}
+            className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-sm text-slate-100"
+          >
+            <span className="block text-xs uppercase tracking-wide text-slate-400">
+              {item.name}
+            </span>
+            <span className="text-base font-medium">{item.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default async function CharacterPage({
+  params,
+}: {
+  params: Promise<{ username: string; characterSlug: string }>;
+}) {
+  const { username, characterSlug } = await params;
+  const result = await getPublicCharacter(username, characterSlug);
+
+  if (!result) {
+    notFound();
+  }
+
+  const { owner, character } = result;
+  const updatedAt = character.updatedAt ? new Date(character.updatedAt) : null;
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-4 py-8 text-slate-100">
+      <Link
+        href={`/profile/${owner.username}`}
+        className="text-sm font-medium text-sky-300 hover:text-sky-200"
+      >
+        ← Back to @{owner.username}
+      </Link>
+
+      <header className="space-y-3">
+        <p className="text-sm uppercase tracking-wide text-slate-400">
+          {owner.profile.displayName}
+        </p>
+        <h1 className="text-3xl font-bold text-slate-100">{character.name}</h1>
+        <div className="flex flex-wrap items-center gap-3 text-sm text-slate-400">
+          <span className="rounded-full border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-300">
+            {formatGameSystem(character.system)}
+          </span>
+          {character.campaign ? (
+            <span>Campaign: {character.campaign}</span>
+          ) : null}
+          {updatedAt ? (
+            <span>Updated {updatedAt.toLocaleDateString()}</span>
+          ) : null}
+        </div>
+      </header>
+
+      {character.notes ? (
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold text-slate-100">Character Notes</h2>
+          <p className="whitespace-pre-line text-base text-slate-200">{character.notes}</p>
+        </section>
+      ) : null}
+
+      <FieldList title="Stats" items={character.stats} />
+      <FieldList title="Skills" items={character.skills} />
+    </div>
+  );
+}

--- a/app/profile/[username]/page.tsx
+++ b/app/profile/[username]/page.tsx
@@ -1,0 +1,129 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { formatGameSystem, getPublicProfile } from "@/lib/public-profiles";
+
+function AvailabilityGrid({
+  availability,
+}: {
+  availability?: Record<string, string[]>;
+}) {
+  if (!availability || Object.keys(availability).length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-lg font-semibold text-slate-100">Availability</h2>
+      <div className="grid gap-3 md:grid-cols-2">
+        {Object.entries(availability).map(([day, slots]) => (
+          <div key={day} className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+            <div className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+              {day}
+            </div>
+            {slots.length > 0 ? (
+              <ul className="mt-1 space-y-1 text-sm text-slate-200">
+                {slots.map((slot) => (
+                  <li key={slot}>{slot}</li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-1 text-sm text-slate-500">No sessions</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default async function PublicProfilePage({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = await params;
+  const profile = await getPublicProfile(username);
+
+  if (!profile) {
+    notFound();
+  }
+
+  const { profile: details, characters } = profile;
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-4 py-8 text-slate-100">
+      <div className="space-y-2">
+        <p className="text-sm uppercase tracking-wide text-sky-400">
+          @{profile.username}
+        </p>
+        <h1 className="text-3xl font-bold">{details.displayName}</h1>
+        {details.location ? (
+          <p className="text-sm text-slate-400">{details.location}</p>
+        ) : null}
+        <p className="max-w-3xl text-base text-slate-200">{details.bio}</p>
+      </div>
+
+      {details.favoriteGames.length > 0 ? (
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold text-slate-100">Favorite Games</h2>
+          <div className="flex flex-wrap gap-2">
+            {details.favoriteGames.map((game) => (
+              <span
+                key={game}
+                className="rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-sm text-sky-100"
+              >
+                {game}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <AvailabilityGrid availability={details.availability} />
+
+      <div className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-100">Characters</h2>
+          <p className="text-sm text-slate-400">
+            Explore the characters shared by {details.displayName}.
+          </p>
+        </div>
+
+        {characters.length === 0 ? (
+          <p className="text-slate-400">No public characters yet.</p>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            {characters.map((character) => (
+              <Link
+                key={character.slug}
+                href={`/profile/${profile.username}/${character.slug}`}
+                className="group rounded-xl border border-slate-800 bg-slate-900/60 p-4 transition hover:border-sky-500/60 hover:bg-slate-900"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-xl font-semibold text-slate-100 group-hover:text-sky-100">
+                      {character.name}
+                    </h3>
+                    <p className="text-sm text-slate-400">
+                      Campaign: {character.campaign || "Unassigned"}
+                    </p>
+                  </div>
+                  <span className="rounded-full border border-slate-700 px-2 py-1 text-xs uppercase tracking-wide text-slate-300">
+                    {formatGameSystem(character.system)}
+                  </span>
+                </div>
+                <p className="mt-3 line-clamp-3 text-sm text-slate-300">
+                  {character.notes}
+                </p>
+                <p className="mt-4 text-sm font-medium text-sky-300">
+                  View details →
+                </p>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 
 
 const GAME_OPTIONS = [
@@ -188,31 +188,6 @@ export default function ProfilePage() {
       };
     });
   };
-
-  const profilePreview = useMemo(
-    () => ({
-      name,
-      commonName,
-      location,
-      zipCode,
-      bio,
-      games: selectedGames,
-      favoriteGames,
-      availability,
-      primaryRole,
-    }),
-    [
-      name,
-      commonName,
-      location,
-      zipCode,
-      bio,
-      selectedGames,
-      favoriteGames,
-      availability,
-      primaryRole,
-    ]
-  );
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/lib/public-profiles.ts
+++ b/lib/public-profiles.ts
@@ -1,0 +1,202 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+import { StoredCharacter } from "./characters/types";
+
+export type PublicProfileDetails = {
+  displayName: string;
+  bio: string;
+  location?: string;
+  favoriteGames: string[];
+  availability?: Record<string, string[]>;
+};
+
+export type PublicCharacterRecord = StoredCharacter & {
+  slug: string;
+};
+
+export type PublicProfileRecord = {
+  username: string;
+  profile: PublicProfileDetails;
+  characters: PublicCharacterRecord[];
+};
+
+const DATA_DIRECTORY = path.join(process.cwd(), "data");
+const PUBLIC_PROFILE_FILE = path.join(DATA_DIRECTORY, "public-profiles.json");
+
+const FALLBACK_PROFILES: PublicProfileRecord[] = [
+  {
+    username: "adventurer-jane",
+    profile: {
+      displayName: "Adventurer Jane",
+      bio: "Story-driven GM and occasional player who loves weaving character-focused tales.",
+      location: "Seattle, WA",
+      favoriteGames: [
+        "Dungeons & Dragons",
+        "Blades in the Dark",
+        "Monster of the Week",
+      ],
+      availability: {
+        Monday: ["7:00 PM"],
+        Wednesday: ["6:00 PM", "8:00 PM"],
+        Saturday: ["2:00 PM"],
+      },
+    },
+    characters: [
+      {
+        slug: "lirael-the-bold",
+        id: "lirael-the-bold",
+        name: "Lirael the Bold",
+        system: "dnd",
+        campaign: "Crown of the First Dawn",
+        stats: [
+          { name: "Strength", value: "+2" },
+          { name: "Dexterity", value: "+3" },
+          { name: "Constitution", value: "+1" },
+          { name: "Intelligence", value: "+0" },
+          { name: "Wisdom", value: "+1" },
+          { name: "Charisma", value: "+4" },
+        ],
+        skills: [
+          { name: "Acrobatics", value: "+5" },
+          { name: "Persuasion", value: "+7" },
+          { name: "Performance", value: "+6" },
+        ],
+        notes:
+          "A traveling bard seeking the lost verses of the First Dawn to restore hope to her homeland.",
+        createdAt: "2024-01-04T18:10:00.000Z",
+        updatedAt: "2024-04-22T09:45:00.000Z",
+      },
+      {
+        slug: "professor-ixion",
+        id: "professor-ixion",
+        name: "Professor Ixion",
+        system: "other",
+        campaign: "Echoes of the Liminal Lab",
+        stats: [
+          { name: "Reason", value: "d10" },
+          { name: "Courage", value: "d8" },
+          { name: "Adaptability", value: "d6" },
+        ],
+        skills: [
+          { name: "Occult Theory", value: "+3" },
+          { name: "Temporal Engineering", value: "+4" },
+        ],
+        notes:
+          "A scientist-turned-occultist experimenting with planar echoes to seal a growing rift.",
+        createdAt: "2024-02-15T16:00:00.000Z",
+        updatedAt: "2024-05-05T12:30:00.000Z",
+      },
+    ],
+  },
+];
+
+function cloneProfiles(source: PublicProfileRecord[]): PublicProfileRecord[] {
+  return source.map((entry) => ({
+    ...entry,
+    profile: {
+      displayName: entry.profile.displayName,
+      bio: entry.profile.bio,
+      location: entry.profile.location,
+      favoriteGames: Array.isArray(entry.profile.favoriteGames)
+        ? [...entry.profile.favoriteGames]
+        : [],
+      availability: entry.profile.availability
+        ? { ...entry.profile.availability }
+        : undefined,
+    },
+    characters: Array.isArray(entry.characters)
+      ? entry.characters.map((character) => ({
+          ...character,
+          stats: character.stats.map((stat) => ({ ...stat })),
+          skills: character.skills.map((skill) => ({ ...skill })),
+        }))
+      : [],
+  }));
+}
+
+async function ensureDataFile(): Promise<void> {
+  await fs.mkdir(DATA_DIRECTORY, { recursive: true });
+
+  try {
+    await fs.access(PUBLIC_PROFILE_FILE);
+  } catch {
+    await fs.writeFile(
+      PUBLIC_PROFILE_FILE,
+      JSON.stringify(FALLBACK_PROFILES, null, 2),
+      "utf8"
+    );
+  }
+}
+
+async function readAllPublicProfiles(): Promise<PublicProfileRecord[]> {
+  await ensureDataFile();
+  const fileContents = await fs.readFile(PUBLIC_PROFILE_FILE, "utf8");
+
+  if (!fileContents.trim()) {
+    return cloneProfiles(FALLBACK_PROFILES);
+  }
+
+  try {
+    const parsed = JSON.parse(fileContents) as PublicProfileRecord[];
+    if (!Array.isArray(parsed)) {
+      return cloneProfiles(FALLBACK_PROFILES);
+    }
+
+    if (parsed.length === 0) {
+      return cloneProfiles(FALLBACK_PROFILES);
+    }
+
+    return cloneProfiles(parsed);
+  } catch (error) {
+    console.error("Failed to parse public profiles", error);
+    return cloneProfiles(FALLBACK_PROFILES);
+  }
+}
+
+export async function getPublicProfile(
+  username: string
+): Promise<PublicProfileRecord | null> {
+  const profiles = await readAllPublicProfiles();
+  const normalized = username.trim().toLowerCase();
+
+  return (
+    profiles.find((profile) => profile.username.toLowerCase() === normalized) ??
+    null
+  );
+}
+
+export async function getPublicCharacter(
+  username: string,
+  slug: string
+): Promise<{ owner: PublicProfileRecord; character: PublicCharacterRecord } | null> {
+  const owner = await getPublicProfile(username);
+
+  if (!owner) {
+    return null;
+  }
+
+  const normalizedSlug = slug.trim().toLowerCase();
+  const character = owner.characters.find(
+    (entry) => entry.slug.toLowerCase() === normalizedSlug
+  );
+
+  if (!character) {
+    return null;
+  }
+
+  return { owner, character };
+}
+
+export function formatGameSystem(system: string): string {
+  switch (system) {
+    case "dnd":
+      return "Dungeons & Dragons";
+    case "pathfinder":
+      return "Pathfinder";
+    case "starfinder":
+      return "Starfinder";
+    default:
+      return "Homebrew / Other";
+  }
+}


### PR DESCRIPTION
## Summary
- add API routes for fetching public profiles and characters by slug
- create server-rendered profile and character pages that consume shared public profile data
- seed filesystem-backed storage with a fallback public profile and expose display helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ded11100788326b49588982c65acc1