### PR TITLE
Add subscription flow for multi-session campaign payments

### DIFF
--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -412,14 +412,25 @@ export default function CampaignDetailPage() {
           )}
         </div>
 
-        {campaign.description && (
-          <div className="mt-4 border-t border-slate-800 pt-4">
-            <p className="text-slate-300">{campaign.description}</p>
-          </div>
-        )}
-      </div>
+      {campaign.description && (
+        <div className="mt-4 border-t border-slate-800 pt-4">
+          <p className="text-slate-300">{campaign.description}</p>
+        </div>
+      )}
 
-      {isCreator && (
+      {campaign.costPerSession && campaign.costPerSession > 0 && (
+        <div className="mt-6">
+          <Link
+            href={`/campaigns/${campaign.id}/payment`}
+            className="inline-flex items-center gap-2 rounded-xl border border-sky-500/40 bg-sky-500/10 px-4 py-2 text-sm font-medium text-sky-200 transition hover:border-sky-500 hover:bg-sky-500/20"
+          >
+            Proceed to payment
+          </Link>
+        </div>
+      )}
+    </div>
+
+    {isCreator && (
         <div className="rounded-lg border border-slate-800 bg-slate-950/40">
           <div className="border-b border-slate-800">
             <div className="flex gap-4 px-6">

--- a/app/post-campaign/page.tsx
+++ b/app/post-campaign/page.tsx
@@ -466,23 +466,27 @@ export default function PostCampaignPage() {
 						<p className="text-xs text-slate-500 mb-4">
 							Players will be required to pay ${costPerSession} per session using Stripe when they join this campaign.
 						</p>
-						{!showPaymentForm && (
-							<button
-								type="button"
-								onClick={async () => {
-									try {
-										// Create payment intent for the campaign owner to set up payment
-										const response = await fetch("/api/stripe/create-payment-intent", {
-											method: "POST",
-											headers: { "Content-Type": "application/json" },
-											body: JSON.stringify({
-												amount: costPerSession,
-												campaignName: selectedGame === "Other" ? customGameName : selectedGame,
-											}),
-										});
-										
-										if (!response.ok) {
-											throw new Error("Failed to initialize payment");
+                                                {!showPaymentForm && (
+                                                        <button
+                                                                type="button"
+                                                                onClick={async () => {
+                                                                        try {
+                                                                                const isSubscription =
+                                                                                        typeof sessionsLeft === "number" &&
+                                                                                        sessionsLeft > 1;
+                                                                                // Create payment intent for the campaign owner to set up payment
+                                                                                const response = await fetch("/api/stripe/create-payment-intent", {
+                                                                                        method: "POST",
+                                                                                        headers: { "Content-Type": "application/json" },
+                                                                                        body: JSON.stringify({
+                                                                                                amount: costPerSession,
+                                                                                                campaignName: selectedGame === "Other" ? customGameName : selectedGame,
+                                                                                                paymentType: isSubscription ? "subscription" : "one_time",
+                                                                                        }),
+                                                                                });
+
+                                                                                if (!response.ok) {
+                                                                                        throw new Error("Failed to initialize payment");
 										}
 										
 										const { clientSecret: secret } = await response.json();
@@ -497,13 +501,18 @@ export default function PostCampaignPage() {
 								Set Up Stripe Payment
 							</button>
 						)}
-						{showPaymentForm && clientSecret && (
-							<StripePaymentForm
-								clientSecret={clientSecret}
-								onSuccess={() => {
-									setPaymentCompleted(true);
-									setShowPaymentForm(false);
-								}}
+                                                {showPaymentForm && clientSecret && (
+                                                        <StripePaymentForm
+                                                                clientSecret={clientSecret}
+                                                                paymentMode={
+                                                                        typeof sessionsLeft === "number" && sessionsLeft > 1
+                                                                                ? "subscription"
+                                                                                : "payment"
+                                                                }
+                                                                onSuccess={() => {
+                                                                        setPaymentCompleted(true);
+                                                                        setShowPaymentForm(false);
+                                                                }}
 								onError={(error) => setError(error)}
 							/>
 						)}

--- a/components/StripePaymentForm.tsx
+++ b/components/StripePaymentForm.tsx
@@ -16,11 +16,16 @@ const stripePromise = loadStripe(
 
 interface PaymentFormProps {
   clientSecret: string;
+  paymentMode?: "payment" | "subscription";
   onSuccess?: () => void;
   onError?: (error: string) => void;
 }
 
-function CheckoutForm({ onSuccess, onError }: Omit<PaymentFormProps, "clientSecret">) {
+function CheckoutForm({
+  onSuccess,
+  onError,
+  paymentMode = "payment",
+}: Omit<PaymentFormProps, "clientSecret">) {
   const stripe = useStripe();
   const elements = useElements();
   const [message, setMessage] = useState<string | null>(null);
@@ -48,7 +53,11 @@ function CheckoutForm({ onSuccess, onError }: Omit<PaymentFormProps, "clientSecr
       setMessage(error.message || "An unexpected error occurred.");
       onError?.(error.message || "An unexpected error occurred.");
     } else {
-      setMessage("Payment successful!");
+      setMessage(
+        paymentMode === "subscription"
+          ? "Subscription started successfully!"
+          : "Payment successful!"
+      );
       onSuccess?.();
     }
 
@@ -76,7 +85,11 @@ function CheckoutForm({ onSuccess, onError }: Omit<PaymentFormProps, "clientSecr
         disabled={isLoading || !stripe || !elements}
         className="w-full rounded-xl bg-sky-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50"
       >
-        {isLoading ? "Processing..." : "Pay Now"}
+        {isLoading
+          ? "Processing..."
+          : paymentMode === "subscription"
+            ? "Subscribe Now"
+            : "Pay Now"}
       </button>
     </form>
   );
@@ -84,6 +97,7 @@ function CheckoutForm({ onSuccess, onError }: Omit<PaymentFormProps, "clientSecr
 
 export default function StripePaymentForm({
   clientSecret,
+  paymentMode = "payment",
   onSuccess,
   onError,
 }: PaymentFormProps) {
@@ -136,7 +150,11 @@ export default function StripePaymentForm({
   return (
     <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-6">
       <Elements stripe={stripePromise} options={options}>
-        <CheckoutForm onSuccess={onSuccess} onError={onError} />
+        <CheckoutForm
+          paymentMode={paymentMode}
+          onSuccess={onSuccess}
+          onError={onError}
+        />
       </Elements>
     </div>
   );


### PR DESCRIPTION
## Summary
- add subscription support to the Stripe checkout API and payment form so multi-session campaigns can create recurring payments
- ensure the campaign creation flow requests the proper payment mode based on the number of sessions
- introduce a dedicated campaign payment page and link it from campaign details for easy access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e58164cfd883268f6ed5ed16f37359