### PR TITLE
Handle missing Stripe configuration gracefully

### DIFF
--- a/app/api/stripe/create-payment-intent/route.ts
+++ b/app/api/stripe/create-payment-intent/route.ts
@@ -13,6 +13,14 @@ const getStripe = () => {
 };
 
 export async function POST(request: Request) {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    console.error("Error creating payment intent: STRIPE_SECRET_KEY is not configured");
+    return NextResponse.json(
+      { error: "Stripe is not configured on the server." },
+      { status: 500 }
+    );
+  }
+
   try {
     const stripe = getStripe();
     const cookieStore = await cookies();

--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -269,12 +269,15 @@ export default function CampaignDetailPage() {
         body: JSON.stringify({ content: newNoteContent.trim() }),
       });
 
+      const data = (await response.json()) as CampaignNote & {
+        error?: string;
+      };
+
       if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || "Failed to add note");
+        throw new Error(data?.error || "Failed to add note");
       }
 
-      const newNote = await response.json();
+      const newNote: CampaignNote = data;
       setNotes((prev) => [newNote, ...prev]);
       setNewNoteContent("");
     } catch (error) {

--- a/components/StripePaymentForm.tsx
+++ b/components/StripePaymentForm.tsx
@@ -11,7 +11,9 @@ import {
 import { STRIPE_PUBLISHABLE_KEY } from "@/lib/stripe-config";
 
 // Load Stripe outside of component to avoid recreating on every render
-const stripePromise = loadStripe(STRIPE_PUBLISHABLE_KEY);
+const stripePromise = STRIPE_PUBLISHABLE_KEY
+  ? loadStripe(STRIPE_PUBLISHABLE_KEY)
+  : null;
 
 interface PaymentFormProps {
   clientSecret: string;
@@ -100,6 +102,7 @@ export default function StripePaymentForm({
   onSuccess,
   onError,
 }: PaymentFormProps) {
+  const stripeInstance = stripePromise;
   const [options, setOptions] = useState<{
     clientSecret: string;
     appearance: {
@@ -135,7 +138,7 @@ export default function StripePaymentForm({
   }, [clientSecret]);
 
   // Check if Stripe publishable key is missing
-  if (!STRIPE_PUBLISHABLE_KEY) {
+  if (!STRIPE_PUBLISHABLE_KEY || !stripeInstance) {
     return (
       <div className="rounded-xl border border-red-500/40 bg-red-500/10 p-6">
         <p className="text-sm text-red-200">
@@ -159,7 +162,7 @@ export default function StripePaymentForm({
 
   return (
     <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-6">
-      <Elements stripe={stripePromise} options={options}>
+      <Elements stripe={stripeInstance} options={options}>
         <CheckoutForm
           paymentMode={paymentMode}
           onSuccess={onSuccess}


### PR DESCRIPTION
## Summary
- prevent the Stripe payment form from initializing with an empty publishable key and surface a clear configuration message
- stop double-reading the campaign notes response body to avoid body stream errors when adding notes
- return a descriptive error when the Stripe secret key is missing on the payment intent endpoint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5ae0a4e288326a44004140d7220b5