### PR TITLE
Retrieve subscription payment intent when expanded as ID

### DIFF
--- a/app/api/stripe/create-payment-intent/route.ts
+++ b/app/api/stripe/create-payment-intent/route.ts
@@ -1,6 +1,37 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import Stripe from "stripe";
+import { STRIPE_NOT_CONFIGURED_MESSAGE } from "@/lib/stripe-messages";
+
+type StripeErrorLike = {
+  type?: string;
+  code?: string;
+  message?: string;
+};
+
+const isStripeMisconfigurationError = (error: unknown) => {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const { type, code, message } = error as StripeErrorLike;
+
+  if (type === "StripeAuthenticationError" || code === "authentication_error") {
+    return true;
+  }
+
+  if (typeof message === "string") {
+    const normalizedMessage = message.toLowerCase();
+    if (
+      normalizedMessage.includes("invalid api key") ||
+      normalizedMessage.includes("no api key provided")
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+};
 
 // Initialize Stripe only if the secret key is available
 const getStripe = () => {
@@ -13,6 +44,14 @@ const getStripe = () => {
 };
 
 export async function POST(request: Request) {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    console.error("Error creating payment intent: STRIPE_SECRET_KEY is not configured");
+    return NextResponse.json(
+      { error: STRIPE_NOT_CONFIGURED_MESSAGE },
+      { status: 503 }
+    );
+  }
+
   try {
     const stripe = getStripe();
     const cookieStore = await cookies();
@@ -82,9 +121,21 @@ export async function POST(request: Request) {
 
       // When using expand, payment_intent is added to the invoice but TypeScript doesn't know about it
       // Use type assertion to access the expanded property
-      const paymentIntent = (latestInvoice as Stripe.Invoice & { payment_intent?: string | Stripe.PaymentIntent }).payment_intent;
+      let paymentIntent = (
+        latestInvoice as Stripe.Invoice & {
+          payment_intent?: string | Stripe.PaymentIntent;
+        }
+      ).payment_intent;
 
-      if (!paymentIntent || typeof paymentIntent === "string") {
+      if (!paymentIntent) {
+        throw new Error("Failed to initialize subscription payment");
+      }
+
+      if (typeof paymentIntent === "string") {
+        paymentIntent = await stripe.paymentIntents.retrieve(paymentIntent);
+      }
+
+      if (!paymentIntent?.client_secret) {
         throw new Error("Failed to initialize subscription payment");
       }
 
@@ -118,8 +169,21 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("Error creating payment intent:", error);
+
+    if (isStripeMisconfigurationError(error)) {
+      return NextResponse.json(
+        { error: STRIPE_NOT_CONFIGURED_MESSAGE },
+        { status: 503 }
+      );
+    }
+
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : "Failed to create payment intent";
+
     return NextResponse.json(
-      { error: "Failed to create payment intent" },
+      { error: message },
       { status: 500 }
     );
   }

--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -95,9 +95,12 @@ export default function CampaignDetailPage() {
 
         // Fetch current user ID
         const profileResponse = await fetch("/api/profile");
+        let profileData: { userId: string } | null = null;
         if (profileResponse.ok) {
-          const profileData = await profileResponse.json();
-          setCurrentUserId(profileData.userId);
+          profileData = await profileResponse.json();
+          if (profileData?.userId) {
+            setCurrentUserId(profileData.userId);
+          }
         }
 
         // Fetch campaign
@@ -231,14 +234,11 @@ export default function CampaignDetailPage() {
         }
 
         // Fetch notes if user is the creator
-        if (profileResponse.ok) {
-          const profileData = await profileResponse.json();
-          if (campaignData.userId === profileData.userId) {
-            const notesResponse = await fetch(`/api/campaigns/${campaignId}/notes`);
-            if (notesResponse.ok) {
-              const notesData = await notesResponse.json();
-              setNotes(notesData);
-            }
+        if (profileData && campaignData.userId === profileData.userId) {
+          const notesResponse = await fetch(`/api/campaigns/${campaignId}/notes`);
+          if (notesResponse.ok) {
+            const notesData = await notesResponse.json();
+            setNotes(notesData);
           }
         }
       } catch (error) {
@@ -269,12 +269,15 @@ export default function CampaignDetailPage() {
         body: JSON.stringify({ content: newNoteContent.trim() }),
       });
 
+      const data = (await response.json()) as CampaignNote & {
+        error?: string;
+      };
+
       if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || "Failed to add note");
+        throw new Error(data?.error || "Failed to add note");
       }
 
-      const newNote = await response.json();
+      const newNote: CampaignNote = data;
       setNotes((prev) => [newNote, ...prev]);
       setNewNoteContent("");
     } catch (error) {

--- a/app/campaigns/[id]/payment/page.tsx
+++ b/app/campaigns/[id]/payment/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import StripePaymentForm from "@/components/StripePaymentForm";
+import { STRIPE_PUBLISHABLE_KEY } from "@/lib/stripe-config";
+import { STRIPE_NOT_CONFIGURED_MESSAGE } from "@/lib/stripe-messages";
 
 interface Campaign {
   id: string;
@@ -62,6 +64,12 @@ export default function CampaignPaymentPage() {
 
   useEffect(() => {
     const initializePayment = async () => {
+      if (!STRIPE_PUBLISHABLE_KEY) {
+        setError(STRIPE_NOT_CONFIGURED_MESSAGE);
+        setClientSecret(null);
+        return;
+      }
+
       if (!campaign?.costPerSession || campaign.costPerSession <= 0) {
         return;
       }
@@ -79,13 +87,43 @@ export default function CampaignPaymentPage() {
           }),
         });
 
-        if (!response.ok) {
-          throw new Error("Failed to initialize payment");
+        let data: unknown;
+
+        try {
+          data = await response.json();
+        } catch (parseError) {
+          if (!response.ok) {
+            throw new Error("Failed to initialize payment");
+          }
+          throw parseError;
         }
 
-        const data = await response.json();
-        setClientSecret(data.clientSecret);
+        if (!response.ok) {
+          if (response.status === 503) {
+            throw new Error(STRIPE_NOT_CONFIGURED_MESSAGE);
+          }
+
+          const message =
+            data && typeof data === "object" && "error" in data && data.error
+              ? String((data as { error: unknown }).error)
+              : "Failed to initialize payment";
+          throw new Error(message);
+        }
+
+        if (
+          !data ||
+          typeof data !== "object" ||
+          !("clientSecret" in data) ||
+          typeof data.clientSecret !== "string"
+        ) {
+          throw new Error("Payment configuration is incomplete. Please try again later.");
+        }
+
+        const clientSecret = (data as { clientSecret: string }).clientSecret;
+        setClientSecret(clientSecret);
+        setError(null);
       } catch (err) {
+        setClientSecret(null);
         setError(err instanceof Error ? err.message : "Failed to initialize payment");
       } finally {
         setIsInitializingPayment(false);

--- a/components/StripePaymentForm.tsx
+++ b/components/StripePaymentForm.tsx
@@ -9,9 +9,12 @@ import {
   useElements,
 } from "@stripe/react-stripe-js";
 import { STRIPE_PUBLISHABLE_KEY } from "@/lib/stripe-config";
+import { STRIPE_NOT_CONFIGURED_MESSAGE } from "@/lib/stripe-messages";
 
 // Load Stripe outside of component to avoid recreating on every render
-const stripePromise = loadStripe(STRIPE_PUBLISHABLE_KEY);
+const stripePromise = STRIPE_PUBLISHABLE_KEY
+  ? loadStripe(STRIPE_PUBLISHABLE_KEY)
+  : null;
 
 interface PaymentFormProps {
   clientSecret: string;
@@ -100,6 +103,7 @@ export default function StripePaymentForm({
   onSuccess,
   onError,
 }: PaymentFormProps) {
+  const stripeInstance = stripePromise;
   const [options, setOptions] = useState<{
     clientSecret: string;
     appearance: {
@@ -135,12 +139,10 @@ export default function StripePaymentForm({
   }, [clientSecret]);
 
   // Check if Stripe publishable key is missing
-  if (!STRIPE_PUBLISHABLE_KEY) {
+  if (!STRIPE_PUBLISHABLE_KEY || !stripeInstance) {
     return (
       <div className="rounded-xl border border-red-500/40 bg-red-500/10 p-6">
-        <p className="text-sm text-red-200">
-          Payment system is not configured. Please contact support.
-        </p>
+        <p className="text-sm text-red-200">{STRIPE_NOT_CONFIGURED_MESSAGE}</p>
       </div>
     );
   }
@@ -159,7 +161,7 @@ export default function StripePaymentForm({
 
   return (
     <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-6">
-      <Elements stripe={stripePromise} options={options}>
+      <Elements stripe={stripeInstance} options={options}>
         <CheckoutForm
           paymentMode={paymentMode}
           onSuccess={onSuccess}

--- a/lib/stripe-messages.ts
+++ b/lib/stripe-messages.ts
@@ -1,0 +1,2 @@
+export const STRIPE_NOT_CONFIGURED_MESSAGE =
+  "Payments are currently unavailable because Stripe is not configured. Please contact support.";


### PR DESCRIPTION
## Summary
- ensure the subscription checkout retrieves the PaymentIntent when Stripe returns only its ID so initialization can complete

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5ae0a4e288326a44004140d7220b5