### PR TITLE
Fix Stripe API version for payment intent creation

### DIFF
--- a/app/api/stripe/create-payment-intent/route.ts
+++ b/app/api/stripe/create-payment-intent/route.ts
@@ -46,9 +46,13 @@ const getStripe = () => {
 	if (!process.env.STRIPE_SECRET_KEY) {
 		throw new Error("STRIPE_SECRET_KEY is not configured");
 	}
-	return new Stripe(process.env.STRIPE_SECRET_KEY, {
-		apiVersion: "2025-09-30.clover",
-	});
+        return new Stripe(process.env.STRIPE_SECRET_KEY, {
+                // Use a stable, GA Stripe API version so requests do not fail
+                // during initialization. The previous value referenced a future
+                // dated ".clover" version which Stripe rejects, preventing
+                // payment intents from being created.
+                apiVersion: "2024-04-10",
+        });
 };
 
 export async function POST(request: Request) {

--- a/scripts/validate-stripe.js
+++ b/scripts/validate-stripe.js
@@ -98,7 +98,9 @@ console.log('\n🔌 Testing Stripe API connection...');
 
 const Stripe = require('stripe');
 const stripe = new Stripe(secretKey, {
-  apiVersion: '2025-09-30.clover',
+  // Match the stable API version used by the application so validation
+  // mirrors runtime behaviour.
+  apiVersion: '2024-04-10',
 });
 
 // Test API call - list products (lightweight operation)


### PR DESCRIPTION
## Summary
- update Stripe client initialization to use a stable API version so payment intents can be created
- align the Stripe validation script with the runtime API version to keep configuration checks accurate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6f35553948326b0751e7c3c6dc6ce