### PR TITLE
Revamp marketing support pages to match ambassador styling

### DIFF
--- a/app/advertising/page.tsx
+++ b/app/advertising/page.tsx
@@ -1,252 +1,262 @@
 import Link from "next/link";
 
+function MegaphoneIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <path d="m3 11 18-5v12L3 13v8H1V5h2z" />
+                        <path d="M11 12v9" />
+                </svg>
+        );
+}
+
+function TargetIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <circle cx="12" cy="12" r="9" />
+                        <circle cx="12" cy="12" r="5" />
+                        <circle cx="12" cy="12" r="1" />
+                </svg>
+        );
+}
+
+function ChartIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <path d="M3 3v18h18" />
+                        <rect x="7" y="12" width="3" height="6" rx="0.5" />
+                        <rect x="12" y="9" width="3" height="9" rx="0.5" />
+                        <rect x="17" y="6" width="3" height="12" rx="0.5" />
+                </svg>
+        );
+}
+
+const keyFeatures = [
+        "2:1 Aspect Ratio Images (800x400px recommended) that auto-scale for mobile",
+        "Location-Based Targeting that reaches users within 50 miles of your chosen zip code",
+        "Smart competition handling so the closest ad is shown when multiple target the same area",
+        "Clickable ads with a URL that opens in a new window",
+        "Performance tracking for unique impressions (per user per hour) and total clicks",
+];
+
+const howItWorks = [
+        {
+                title: "Geographic Targeting",
+                description:
+                        "Specify a zip code for your advertisement and it will display to players within a 50-mile radius—ideal for stores, events, and regional offerings.",
+        },
+        {
+                title: "Automatic Optimization",
+                description:
+                        "When campaigns overlap, The Gathering Call automatically prioritizes the ad closest to each player, ensuring the most relevant content appears first.",
+        },
+        {
+                title: "Responsive Design",
+                description:
+                        "Your 2:1 artwork scales seamlessly from desktop monitors to phones. On smaller screens, ads resize to 90% width for clear, legible messaging.",
+        },
+        {
+                title: "Click-Through Actions",
+                description:
+                        "Attach a URL to send players directly to your store, registration form, or landing page whenever they tap your banner.",
+        },
+        {
+                title: "Performance Analytics",
+                description:
+                        "Monitor impressions and clicks directly in the platform so you can fine-tune creatives, offers, and timing with confidence.",
+        },
+];
+
+const placements = [
+        { title: "Find Games", description: "Showcase one-shots to active players searching for a new table right now." },
+        { title: "Find Campaigns", description: "Reach long-form adventurers browsing for their next ongoing story." },
+        { title: "My Campaigns", description: "Stay in front of engaged players managing their schedules and groups." },
+];
+
+const idealFor = [
+        {
+                title: "Local Game Stores",
+                description: "Promote in-store events, product releases, or weekly play nights to nearby players.",
+        },
+        {
+                title: "Gaming Conventions",
+                description: "Drive ticket sales and highlight panels, guests, or tournaments before badges sell out.",
+        },
+        {
+                title: "Publishers & Creators",
+                description: "Launch new games, supplements, or crowdfunding campaigns to an audience ready to support you.",
+        },
+        {
+                title: "Gaming Services",
+                description: "Advertise VTT tools, streaming services, character creators, or other tabletop solutions.",
+        },
+];
+
 export default function AdvertisingPage() {
-	return (
-		<div className="mx-auto max-w-4xl px-4 py-12">
-			<div className="space-y-8">
-				<div>
-					<h1 className="text-3xl font-bold text-slate-100">
-						Advertising on The Gathering Call
-					</h1>
-					<p className="mt-2 text-slate-400">
-						Reach your target audience of tabletop gaming enthusiasts with our location-based advertising platform.
-					</p>
-				</div>
+        return (
+                <div className="mx-auto max-w-5xl space-y-8 py-8">
+                        <div className="rounded-3xl border-2 border-amber-500/50 bg-gradient-to-br from-amber-600/20 via-purple-600/20 to-indigo-600/20 p-8 shadow-2xl">
+                                <div className="text-center space-y-4">
+                                        <div className="flex justify-center gap-4">
+                                                <MegaphoneIcon className="h-8 w-8 text-amber-400" />
+                                                <TargetIcon className="h-8 w-8 text-purple-300" />
+                                                <ChartIcon className="h-8 w-8 text-indigo-300" />
+                                        </div>
+                                        <h1 className="text-4xl font-bold bg-gradient-to-r from-amber-400 via-purple-400 to-indigo-400 bg-clip-text text-transparent">
+                                                Advertising on The Gathering Call
+                                        </h1>
+                                        <p className="text-slate-200 max-w-2xl mx-auto">
+                                                Reach tabletop fans with location-based promotions crafted specifically for the adventures they love.
+                                        </p>
+                                </div>
+                        </div>
 
-				{/* Overview Section */}
-				<section className="rounded-xl border border-slate-800/60 bg-slate-900/40 p-6">
-					<h2 className="text-2xl font-semibold text-slate-100 mb-4">
-						Advertising Capabilities
-					</h2>
-					<p className="text-slate-300 mb-4">
-						The Gathering Call offers a powerful advertising platform designed specifically for reaching 
-						tabletop gaming communities. Our location-based advertising ensures your message reaches the 
-						right audience at the right place.
-					</p>
-					<div className="rounded-lg border border-sky-700/50 bg-sky-900/20 p-4">
-						<h3 className="text-sm font-medium text-sky-200 mb-2">
-							Key Features
-						</h3>
-						<ul className="space-y-2 text-sm text-slate-300">
-							<li className="flex items-start gap-2">
-								<span className="text-sky-400 mt-1">•</span>
-								<span><strong>2:1 Aspect Ratio Images:</strong> Professional banner format (800x400px recommended) that auto-scales for mobile devices</span>
-							</li>
-							<li className="flex items-start gap-2">
-								<span className="text-sky-400 mt-1">•</span>
-								<span><strong>Location-Based Targeting:</strong> Ads are shown to users within 50 miles of your specified zip code</span>
-							</li>
-							<li className="flex items-start gap-2">
-								<span className="text-sky-400 mt-1">•</span>
-								<span><strong>Smart Competition Handling:</strong> If multiple ads target the same area, the geographically closest ad is shown to each user</span>
-							</li>
-							<li className="flex items-start gap-2">
-								<span className="text-sky-400 mt-1">•</span>
-								<span><strong>Clickable Ads:</strong> Include a URL that opens in a new window when users click your advertisement</span>
-							</li>
-							<li className="flex items-start gap-2">
-								<span className="text-sky-400 mt-1">•</span>
-								<span><strong>Performance Tracking:</strong> Track unique impressions (per user per hour) and total clicks on your advertisement</span>
-							</li>
-						</ul>
-					</div>
-				</section>
+                        <section className="rounded-2xl border border-white/10 bg-slate-900/60 p-8 shadow-xl">
+                                <h2 className="text-2xl font-semibold text-amber-300">Platform Highlights</h2>
+                                <p className="mt-3 text-sm text-slate-300">
+                                        The Gathering Call provides a dedicated advertising network tailored to the tabletop community. Every placement is curated to put your promotion in front of players and Game Masters who are ready to discover new experiences.
+                                </p>
+                                <ul className="mt-6 space-y-3 text-sm text-slate-200/90">
+                                        {keyFeatures.map((feature) => (
+                                                <li key={feature} className="flex items-start gap-3">
+                                                        <span className="mt-1 text-amber-300">•</span>
+                                                        <span>{feature}</span>
+                                                </li>
+                                        ))}
+                                </ul>
+                        </section>
 
-				{/* How It Works */}
-				<section className="rounded-xl border border-slate-800/60 bg-slate-900/40 p-6">
-					<h2 className="text-2xl font-semibold text-slate-100 mb-4">
-						How It Works
-					</h2>
-					<div className="space-y-4 text-slate-300">
-						<div>
-							<h3 className="text-lg font-medium text-slate-200 mb-2">
-								1. Geographic Targeting
-							</h3>
-							<p className="text-sm">
-								Specify a zip code for your advertisement, and it will be shown to all users within 
-								a 50-mile radius of that location. This ensures your ad reaches local gamers who are 
-								most likely to engage with your business or event.
-							</p>
-						</div>
-						
-						<div>
-							<h3 className="text-lg font-medium text-slate-200 mb-2">
-								2. Automatic Optimization
-							</h3>
-							<p className="text-sm">
-								When multiple advertisements compete for the same audience, our system automatically 
-								prioritizes showing the closest advertisement to each user. This ensures the most 
-								relevant local content is displayed.
-							</p>
-						</div>
-						
-						<div>
-							<h3 className="text-lg font-medium text-slate-200 mb-2">
-								3. Responsive Design
-							</h3>
-							<p className="text-sm">
-								Your 2:1 aspect ratio image automatically scales to fit any device, from mobile phones 
-								to desktop computers. On mobile devices (under 900px width), ads scale to 90% of screen 
-								width for optimal viewing.
-							</p>
-						</div>
+                        <section className="rounded-2xl border border-white/10 bg-slate-900/60 p-8 shadow-xl">
+                                <h2 className="text-2xl font-semibold text-purple-300">How It Works</h2>
+                                <div className="mt-6 grid gap-6 md:grid-cols-2">
+                                        {howItWorks.map((step) => (
+                                                <div key={step.title} className="rounded-xl border border-purple-500/30 bg-purple-500/10 p-5">
+                                                        <h3 className="text-lg font-semibold text-purple-100">{step.title}</h3>
+                                                        <p className="mt-2 text-sm text-slate-100/80">{step.description}</p>
+                                                </div>
+                                        ))}
+                                </div>
+                        </section>
 
-						<div>
-							<h3 className="text-lg font-medium text-slate-200 mb-2">
-								4. Click-Through Actions
-							</h3>
-							<p className="text-sm">
-								Add a URL to your advertisement to drive traffic to your website, event page, or online store. 
-								When users click your ad, they&apos;re taken to your specified URL in a new browser window.
-							</p>
-						</div>
+                        <section className="rounded-2xl border border-white/10 bg-slate-900/60 p-8 shadow-xl">
+                                <h2 className="text-2xl font-semibold text-indigo-300">Where Your Ads Appear</h2>
+                                <p className="mt-3 text-sm text-slate-300">
+                                        Ads are woven into the experience on the highest-traffic surfaces across The Gathering Call platform:
+                                </p>
+                                <div className="mt-6 grid gap-4 md:grid-cols-3">
+                                        {placements.map((placement) => (
+                                                <div key={placement.title} className="rounded-xl border border-indigo-500/30 bg-indigo-500/10 p-4">
+                                                        <h3 className="text-base font-semibold text-indigo-100">{placement.title}</h3>
+                                                        <p className="mt-2 text-xs text-slate-100/80">{placement.description}</p>
+                                                </div>
+                                        ))}
+                                </div>
+                                <p className="mt-6 text-xs text-slate-400 italic">
+                                        Placements sit after the main header and before search tools, maximizing visibility without disrupting discovery.
+                                </p>
+                        </section>
 
-						<div>
-							<h3 className="text-lg font-medium text-slate-200 mb-2">
-								5. Performance Analytics
-							</h3>
-							<p className="text-sm">
-								Track the effectiveness of your advertisement with built-in analytics. Monitor unique 
-								impressions (counted once per user per hour) and total clicks to measure engagement 
-								and adjust your strategy.
-							</p>
-						</div>
-					</div>
-				</section>
+                        <section className="rounded-2xl border border-white/10 bg-slate-900/60 p-8 shadow-xl">
+                                <h2 className="text-2xl font-semibold text-amber-300">Ideal For</h2>
+                                <div className="mt-6 grid gap-5 md:grid-cols-2">
+                                        {idealFor.map((item) => (
+                                                <div key={item.title} className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-5">
+                                                        <h3 className="text-base font-semibold text-amber-100">{item.title}</h3>
+                                                        <p className="mt-2 text-sm text-amber-50/80">{item.description}</p>
+                                                </div>
+                                        ))}
+                                </div>
+                        </section>
 
-				{/* Placement & Visibility */}
-				<section className="rounded-xl border border-slate-800/60 bg-slate-900/40 p-6">
-					<h2 className="text-2xl font-semibold text-slate-100 mb-4">
-						Ad Placement & Visibility
-					</h2>
-					<p className="text-slate-300 mb-3">
-						Your advertisements are prominently displayed on the most visited pages of our platform:
-					</p>
-					<ul className="space-y-2 text-sm text-slate-300 mb-4">
-						<li className="flex items-start gap-2">
-							<span className="text-sky-400">✓</span>
-							<span><strong>Find Games:</strong> Where users search for one-shot gaming sessions</span>
-						</li>
-						<li className="flex items-start gap-2">
-							<span className="text-sky-400">✓</span>
-							<span><strong>Find Campaigns:</strong> Where users browse ongoing campaign opportunities</span>
-						</li>
-						<li className="flex items-start gap-2">
-							<span className="text-sky-400">✓</span>
-							<span><strong>My Campaigns:</strong> User dashboard for managing their gaming activities</span>
-						</li>
-					</ul>
-					<p className="text-sm text-slate-400 italic">
-						Advertisements appear after the page header and before search sections, ensuring maximum visibility 
-						without being intrusive to the user experience.
-					</p>
-				</section>
+                        <section className="rounded-2xl border border-white/10 bg-slate-900/60 p-8 shadow-xl">
+                                <h2 className="text-2xl font-semibold text-slate-100">Technical Specs</h2>
+                                <div className="mt-6 grid gap-4 md:grid-cols-2">
+                                        <div className="rounded-xl border border-white/10 bg-slate-950/60 p-5">
+                                                <dl className="space-y-3 text-sm text-slate-200">
+                                                        <div className="flex justify-between">
+                                                                <dt className="text-slate-400">Image Dimensions</dt>
+                                                                <dd className="font-medium text-slate-100">800×400 (2:1)</dd>
+                                                        </div>
+                                                        <div className="flex justify-between">
+                                                                <dt className="text-slate-400">File Size</dt>
+                                                                <dd className="font-medium text-slate-100">Up to 5 MB</dd>
+                                                        </div>
+                                                        <div className="flex justify-between">
+                                                                <dt className="text-slate-400">Formats</dt>
+                                                                <dd className="font-medium text-slate-100">PNG or JPG</dd>
+                                                        </div>
+                                                        <div className="flex justify-between">
+                                                                <dt className="text-slate-400">Destination Links</dt>
+                                                                <dd className="font-medium text-slate-100">Open in a new tab</dd>
+                                                        </div>
+                                                </dl>
+                                        </div>
+                                        <div className="rounded-xl border border-indigo-500/30 bg-indigo-500/10 p-5">
+                                                <h3 className="text-lg font-semibold text-indigo-100">Pricing</h3>
+                                                <p className="mt-2 text-sm text-slate-100/80">
+                                                        Flat rate of <strong className="text-indigo-50">$20 per location each month</strong>. Purchase multiple locations to cover additional territories.
+                                                </p>
+                                                <ul className="mt-4 space-y-2 text-xs text-slate-100/80">
+                                                        <li>• Locations are defined by zip code</li>
+                                                        <li>• Each location covers a 50-mile radius</li>
+                                                        <li>• When multiple advertisers target the same area, ads rotate based on user proximity</li>
+                                                </ul>
+                                                <p className="mt-4 text-xs text-slate-400 italic">
+                                                        Pricing is subject to change with advance notice to current advertisers.
+                                                </p>
+                                        </div>
+                                </div>
+                        </section>
 
-				{/* Ideal For */}
-				<section className="rounded-xl border border-slate-800/60 bg-slate-900/40 p-6">
-					<h2 className="text-2xl font-semibold text-slate-100 mb-4">
-						Ideal For
-					</h2>
-					<div className="grid gap-4 md:grid-cols-2">
-						<div className="rounded-lg border border-slate-700/50 bg-slate-950/40 p-4">
-							<h3 className="text-base font-medium text-slate-200 mb-2">
-								Local Game Stores
-							</h3>
-							<p className="text-sm text-slate-400">
-								Promote in-store events, new product releases, or gaming nights to players in your area.
-							</p>
-						</div>
-						
-						<div className="rounded-lg border border-slate-700/50 bg-slate-950/40 p-4">
-							<h3 className="text-base font-medium text-slate-200 mb-2">
-								Gaming Conventions
-							</h3>
-							<p className="text-sm text-slate-400">
-								Reach attendees in your convention&apos;s geographic area to boost ticket sales and awareness.
-							</p>
-						</div>
-						
-						<div className="rounded-lg border border-slate-700/50 bg-slate-950/40 p-4">
-							<h3 className="text-base font-medium text-slate-200 mb-2">
-								Publishers & Creators
-							</h3>
-							<p className="text-sm text-slate-400">
-								Launch new games, supplements, or crowdfunding campaigns to an engaged tabletop audience.
-							</p>
-						</div>
-						
-						<div className="rounded-lg border border-slate-700/50 bg-slate-950/40 p-4">
-							<h3 className="text-base font-medium text-slate-200 mb-2">
-								Gaming Services
-							</h3>
-							<p className="text-sm text-slate-400">
-								Advertise virtual tabletops, character tools, streaming services, or other gaming products.
-							</p>
-						</div>
-					</div>
-				</section>
-
-				{/* Technical Specifications */}
-				<section className="rounded-xl border border-slate-800/60 bg-slate-900/40 p-6">
-					<h2 className="text-2xl font-semibold text-slate-100 mb-4">
-						Technical Specifications
-					</h2>
-					<div className="space-y-3 text-sm text-slate-300">
-						<div className="rounded-lg bg-slate-950/40 p-4 border border-slate-800">
-							<div className="grid gap-3">
-								<div className="flex justify-between">
-									<span className="text-slate-400">Image Dimensions:</span>
-									<span className="font-medium text-slate-200">800x400 pixels (2:1 ratio)</span>
-								</div>
-								<div className="flex justify-between">
-									<span className="text-slate-400">File Formats:</span>
-									<span className="font-medium text-slate-200">JPG, PNG, WebP, GIF</span>
-								</div>
-								<div className="flex justify-between">
-									<span className="text-slate-400">Maximum File Size:</span>
-									<span className="font-medium text-slate-200">5MB</span>
-								</div>
-								<div className="flex justify-between">
-									<span className="text-slate-400">Geographic Range:</span>
-									<span className="font-medium text-slate-200">50-mile radius from zip code</span>
-								</div>
-								<div className="flex justify-between">
-									<span className="text-slate-400">Mobile Scaling:</span>
-									<span className="font-medium text-slate-200">Auto-adjusts to 90% width on &lt;900px</span>
-								</div>
-								<div className="flex justify-between">
-									<span className="text-slate-400">Link Behavior:</span>
-									<span className="font-medium text-slate-200">Opens in new window</span>
-								</div>
-							</div>
-						</div>
-					</div>
-				</section>
-
-				{/* Get Started */}
-				<section className="rounded-xl border border-sky-600/40 bg-sky-900/20 p-6 text-center">
-					<h2 className="text-2xl font-semibold text-slate-100 mb-3">
-						Interested in Advertising?
-					</h2>
-					<p className="text-slate-300 mb-6 max-w-2xl mx-auto">
-						Contact us to learn more about advertising opportunities on The Gathering Call and 
-						how we can help you reach the tabletop gaming community.
-					</p>
-					<p className="text-sm text-slate-400">
-						For advertising inquiries, please reach out through our support channels.
-					</p>
-				</section>
-
-				{/* Back to Home */}
-				<div className="text-center">
-					<Link
-						href="/"
-						className="inline-block text-sm text-slate-400 hover:text-slate-300 hover:underline"
-					>
-						← Back to Home
-					</Link>
-				</div>
-			</div>
-		</div>
-	);
+                        <section className="rounded-2xl border-2 border-amber-500/50 bg-gradient-to-br from-amber-600/20 via-purple-600/20 to-indigo-600/20 p-8 text-center shadow-2xl">
+                                <h2 className="text-2xl font-semibold text-slate-100">Ready to Advertise?</h2>
+                                <p className="mt-3 text-sm text-slate-200 max-w-2xl mx-auto">
+                                        Partner with our team to choose locations, design standout creatives, and launch campaigns that resonate with players.
+                                </p>
+                                <div className="mt-6 flex flex-wrap justify-center gap-4">
+                                        <Link
+                                                href="/support"
+                                                className="rounded-lg border border-amber-500/50 bg-amber-500/20 px-5 py-2 text-sm font-medium text-amber-200 transition hover:bg-amber-500/30"
+                                        >
+                                                Contact Support
+                                        </Link>
+                                        <Link
+                                                href="https://discord.gg/Nx9jPfn6Sb"
+                                                className="rounded-lg border border-indigo-500/50 bg-indigo-500/20 px-5 py-2 text-sm font-medium text-indigo-200 transition hover:bg-indigo-500/30"
+                                        >
+                                                Chat on Discord
+                                        </Link>
+                                </div>
+                        </section>
+                </div>
+        );
 }

--- a/app/sms-consent/page.tsx
+++ b/app/sms-consent/page.tsx
@@ -1,212 +1,321 @@
+import Link from "next/link";
+
+function MessageIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <path d="M21 11.5a8.38 8.38 0 0 1-1 3.9 8.5 8.5 0 0 1-7.5 4.6 8.38 8.38 0 0 1-3.9-1l-4.6 1 1-4.6a8.38 8.38 0 0 1-1-3.9 8.5 8.5 0 0 1 4.6-7.5 8.38 8.38 0 0 1 3.9-1h.5a8.48 8.48 0 0 1 8 8Z" />
+                        <path d="M8 12h.01" />
+                        <path d="M12 12h.01" />
+                        <path d="M16 12h.01" />
+                </svg>
+        );
+}
+
+function PhoneIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.05 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92Z" />
+                </svg>
+        );
+}
+
+function ShieldCheckIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <path d="M12 2 4 5v6c0 5.25 3.43 10.39 8 12 4.57-1.61 8-6.75 8-12V5z" />
+                        <path d="m9 12 2 2 4-4" />
+                </svg>
+        );
+}
+
+const sections = [
+        {
+                title: "1. Overview",
+                content: (
+                        <>
+                                <p>
+                                        The Gathering Call offers optional SMS messaging to keep you informed about your tabletop gaming campaigns. By providing your phone number in your profile, you consent to receive SMS notifications from campaign hosts using our platform.
+                                </p>
+                                <p>
+                                        <strong>SMS messaging is completely optional.</strong> You can use all features of The Gathering Call without providing a phone number.
+                                </p>
+                        </>
+                ),
+        },
+        {
+                title: "2. How to Opt In",
+                content: (
+                        <>
+                                <p>To receive SMS notifications:</p>
+                                <ol className="list-decimal list-inside space-y-2 text-slate-200/80">
+                                        <li>Log in to your account on The Gathering Call</li>
+                                        <li>Navigate to your Profile page</li>
+                                        <li>Locate the &quot;Phone Number&quot; field</li>
+                                        <li>Enter your mobile phone number</li>
+                                        <li>Save your profile</li>
+                                </ol>
+                                <p className="mt-3">
+                                        By entering and saving your phone number, you consent to receive SMS messages related to campaigns you have joined.
+                                </p>
+                        </>
+                ),
+        },
+        {
+                title: "3. Types of Messages You May Receive",
+                content: (
+                        <>
+                                <p>When you opt in to SMS notifications, you may receive:</p>
+                                <ul className="list-disc list-inside space-y-2 text-slate-200/80">
+                                        <li>Campaign updates and announcements from hosts</li>
+                                        <li>Schedule changes or cancellations</li>
+                                        <li>Session reminders</li>
+                                        <li>Important campaign-related information</li>
+                                </ul>
+                                <p className="mt-3">
+                                        <strong>Message Frequency:</strong> The number of messages you receive depends on the campaigns you join and how often hosts send updates. Typically, you may receive 1-5 messages per month per campaign.
+                                </p>
+                        </>
+                ),
+        },
+        {
+                title: "4. SMS Service Provider",
+                content: (
+                        <>
+                                <p>
+                                        SMS messages are delivered through Twilio, a third-party messaging service provider. By opting in to SMS notifications:
+                                </p>
+                                <ul className="list-disc list-inside space-y-2 text-slate-200/80">
+                                        <li>Your phone number will be shared with Twilio for the purpose of message delivery</li>
+                                        <li>Twilio&apos;s privacy practices are governed by their own privacy policy</li>
+                                        <li>Messages are sent from a Twilio phone number on behalf of The Gathering Call</li>
+                                </ul>
+                        </>
+                ),
+        },
+        {
+                title: "5. Data Collection and Use",
+                content: (
+                        <>
+                                <p>When you provide your phone number:</p>
+                                <ul className="list-disc list-inside space-y-2 text-slate-200/80">
+                                        <li>
+                                                <strong>What we collect:</strong> Your mobile phone number
+                                        </li>
+                                        <li>
+                                                <strong>How we use it:</strong> Only to send campaign-related SMS notifications
+                                        </li>
+                                        <li>
+                                                <strong>Who can see it:</strong> Your phone number is never visible to anyone, including campaign hosts. It is stored securely and used only for SMS delivery.
+                                        </li>
+                                        <li>
+                                                <strong>How we protect it:</strong> Your phone number is stored securely in our database and never shared publicly or displayed in the application
+                                        </li>
+                                        <li>
+                                                <strong>Retention:</strong> We keep your phone number until you remove it from your profile or delete your account
+                                        </li>
+                                </ul>
+                        </>
+                ),
+        },
+        {
+                title: "6. Message and Data Rates",
+                content: (
+                        <>
+                                <p>
+                                        <strong>Standard message and data rates may apply</strong> when you receive SMS notifications. Check with your mobile carrier for details about your messaging plan.
+                                </p>
+                                <p>
+                                        The Gathering Call does not charge any fees for SMS notifications, but your carrier may charge you for text messages received depending on your plan.
+                                </p>
+                        </>
+                ),
+        },
+        {
+                title: "7. How to Opt Out",
+                content: (
+                        <>
+                                <p>You can stop receiving SMS notifications at any time through any of these methods:</p>
+                                <div className="space-y-4">
+                                        <div>
+                                                <h3 className="text-sm font-semibold text-slate-100">Method 1: Remove Phone Number from Profile</h3>
+                                                <ol className="list-decimal list-inside space-y-2 text-slate-200/80">
+                                                        <li>Log in to your account</li>
+                                                        <li>Go to your Profile page</li>
+                                                        <li>Clear the phone number field</li>
+                                                        <li>Save your profile</li>
+                                                </ol>
+                                        </div>
+                                        <div>
+                                                <h3 className="text-sm font-semibold text-slate-100">Method 2: Reply STOP</h3>
+                                                <p>
+                                                        Reply <strong>STOP</strong> to any SMS message you receive from The Gathering Call. This will immediately opt you out of future SMS notifications.
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <h3 className="text-sm font-semibold text-slate-100">Method 3: Contact Support</h3>
+                                                <p>
+                                                        Contact us through the platform&apos;s support channels and request to be removed from SMS notifications.
+                                                </p>
+                                        </div>
+                                </div>
+                                <p className="mt-3">
+                                        <strong>Note:</strong> After opting out, you will no longer receive SMS notifications, but you will still receive in-app messages through the internal messaging system.
+                                </p>
+                        </>
+                ),
+        },
+        {
+                title: "8. Help and Support",
+                content: (
+                        <>
+                                <p>If you have questions about SMS notifications, you can:</p>
+                                <ul className="list-disc list-inside space-y-2 text-slate-200/80">
+                                        <li>
+                                                Reply <strong>HELP</strong> to any SMS message for assistance
+                                        </li>
+                                        <li>Contact us through the platform&apos;s support channels</li>
+                                        <li>
+                                                Review our <Link href="/privacy" className="text-indigo-200 underline decoration-indigo-400/60 underline-offset-4 transition hover:text-indigo-100">Privacy Policy</Link> for more information about data handling
+                                        </li>
+                                </ul>
+                        </>
+                ),
+        },
+        {
+                title: "9. Your Rights",
+                content: (
+                        <>
+                                <p>You have the right to:</p>
+                                <ul className="list-disc list-inside space-y-2 text-slate-200/80">
+                                        <li>Opt in or opt out of SMS notifications at any time</li>
+                                        <li>Request information about what phone number we have on file</li>
+                                        <li>Request deletion of your phone number from our records</li>
+                                        <li>Change your phone number at any time</li>
+                                        <li>Access all platform features without providing a phone number</li>
+                                </ul>
+                        </>
+                ),
+        },
+        {
+                title: "10. Changes to This Policy",
+                content: (
+                        <>
+                                <p>
+                                        We may update this SMS Consent policy from time to time. When we make changes, we will update the &quot;Last updated&quot; date at the top of this page. Continued use of SMS notifications after changes indicates your acceptance of the updated terms.
+                                </p>
+                                <p>
+                                        If we make material changes to how we handle SMS notifications, we will notify you through the platform or via SMS before the changes take effect.
+                                </p>
+                        </>
+                ),
+        },
+        {
+                title: "11. Compliance",
+                content: (
+                        <>
+                                <p>Our SMS messaging program complies with:</p>
+                                <ul className="list-disc list-inside space-y-2 text-slate-200/80">
+                                        <li>Telephone Consumer Protection Act (TCPA)</li>
+                                        <li>CAN-SPAM Act</li>
+                                        <li>Cellular Telecommunications Industry Association (CTIA) guidelines</li>
+                                        <li>Mobile Marketing Association (MMA) Consumer Best Practices</li>
+                                </ul>
+                        </>
+                ),
+        },
+        {
+                title: "12. Contact Us",
+                content: (
+                        <p>
+                                If you have questions about SMS notifications or this consent policy, please contact us through the platform&apos;s support channels.
+                        </p>
+                ),
+        },
+];
+
 export default function SmsConsentPage() {
-	return (
-		<section className="space-y-6">
-			<div>
-				<h1 className="text-2xl font-semibold text-slate-100">
-					SMS Messaging Consent
-				</h1>
-				<p className="mt-2 text-sm text-slate-400">
-					Last updated: January 10, 2025
-				</p>
-			</div>
+        return (
+                <div className="mx-auto max-w-5xl space-y-8 py-8">
+                        <div className="rounded-3xl border-2 border-amber-500/50 bg-gradient-to-br from-amber-600/20 via-purple-600/20 to-indigo-600/20 p-8 shadow-2xl">
+                                <div className="text-center space-y-4">
+                                        <div className="flex justify-center gap-4">
+                                                <MessageIcon className="h-8 w-8 text-amber-300" />
+                                                <PhoneIcon className="h-8 w-8 text-purple-200" />
+                                                <ShieldCheckIcon className="h-8 w-8 text-indigo-300" />
+                                        </div>
+                                        <h1 className="text-4xl font-bold bg-gradient-to-r from-amber-400 via-purple-400 to-indigo-400 bg-clip-text text-transparent">
+                                                SMS Messaging Consent
+                                        </h1>
+                                        <p className="text-slate-200 max-w-2xl mx-auto">
+                                                Stay up to date with timely campaign alerts while maintaining full control over your phone number and privacy.
+                                        </p>
+                                        <div className="inline-flex rounded-full border border-amber-500/50 bg-amber-500/20 px-5 py-2 text-sm font-semibold text-amber-200">
+                                                Last updated: January 10, 2025
+                                        </div>
+                                </div>
+                        </div>
 
-			<div className="space-y-4 rounded-2xl border border-slate-800/60 bg-slate-900/40 p-6 shadow-lg shadow-slate-900/30">
-				<div className="space-y-4 text-sm text-slate-300 leading-relaxed">
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							1. Overview
-						</h2>
-						<p>
-							The Gathering Call offers optional SMS messaging to keep you informed about your tabletop gaming campaigns. By providing your phone number in your profile, you consent to receive SMS notifications from campaign hosts using our platform.
-						</p>
-						<p>
-							<strong>SMS messaging is completely optional.</strong> You can use all features of The Gathering Call without providing a phone number.
-						</p>
-					</div>
+                        <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-8 shadow-xl">
+                                <div className="space-y-8 text-sm leading-relaxed text-slate-300">
+                                        {sections.map((section) => (
+                                                <div key={section.title} className="space-y-3">
+                                                        <h2 className="text-xl font-semibold text-slate-100">{section.title}</h2>
+                                                        <div className="space-y-3">{section.content}</div>
+                                                </div>
+                                        ))}
+                                </div>
+                        </div>
 
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							2. How to Opt In
-						</h2>
-						<p>
-							To receive SMS notifications:
-						</p>
-						<ol className="list-decimal list-inside space-y-2 ml-2">
-							<li>Log in to your account on The Gathering Call</li>
-							<li>Navigate to your Profile page</li>
-							<li>Locate the &quot;Phone Number&quot; field</li>
-							<li>Enter your mobile phone number</li>
-							<li>Save your profile</li>
-						</ol>
-						<p className="mt-3">
-							By entering and saving your phone number, you consent to receive SMS messages related to campaigns you have joined.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							3. Types of Messages You May Receive
-						</h2>
-						<p>
-							When you opt in to SMS notifications, you may receive:
-						</p>
-						<ul className="list-disc list-inside space-y-2 ml-2">
-							<li>Campaign updates and announcements from hosts</li>
-							<li>Schedule changes or cancellations</li>
-							<li>Session reminders</li>
-							<li>Important campaign-related information</li>
-						</ul>
-						<p className="mt-3">
-							<strong>Message Frequency:</strong> The number of messages you receive depends on the campaigns you join and how often hosts send updates. Typically, you may receive 1-5 messages per month per campaign.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							4. SMS Service Provider
-						</h2>
-						<p>
-							SMS messages are delivered through Twilio, a third-party messaging service provider. By opting in to SMS notifications:
-						</p>
-						<ul className="list-disc list-inside space-y-2 ml-2">
-							<li>Your phone number will be shared with Twilio for the purpose of message delivery</li>
-							<li>Twilio&apos;s privacy practices are governed by their own privacy policy</li>
-							<li>Messages are sent from a Twilio phone number on behalf of The Gathering Call</li>
-						</ul>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							5. Data Collection and Use
-						</h2>
-						<p>
-							When you provide your phone number:
-						</p>
-						<ul className="list-disc list-inside space-y-2 ml-2">
-							<li><strong>What we collect:</strong> Your mobile phone number</li>
-							<li><strong>How we use it:</strong> Only to send campaign-related SMS notifications</li>
-							<li><strong>Who can see it:</strong> Your phone number is never visible to anyone, including campaign hosts. It is stored securely and used only for SMS delivery.</li>
-							<li><strong>How we protect it:</strong> Your phone number is stored securely in our database and never shared publicly or displayed in the application</li>
-							<li><strong>Retention:</strong> We keep your phone number until you remove it from your profile or delete your account</li>
-						</ul>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							6. Message and Data Rates
-						</h2>
-						<p>
-							<strong>Standard message and data rates may apply</strong> when you receive SMS notifications. Check with your mobile carrier for details about your messaging plan.
-						</p>
-						<p>
-							The Gathering Call does not charge any fees for SMS notifications, but your carrier may charge you for text messages received depending on your plan.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							7. How to Opt Out
-						</h2>
-						<p>
-							You can stop receiving SMS notifications at any time through any of these methods:
-						</p>
-						
-						<h3 className="text-base font-medium text-slate-200">
-							Method 1: Remove Phone Number from Profile
-						</h3>
-						<ol className="list-decimal list-inside space-y-2 ml-2">
-							<li>Log in to your account</li>
-							<li>Go to your Profile page</li>
-							<li>Clear the phone number field</li>
-							<li>Save your profile</li>
-						</ol>
-
-						<h3 className="text-base font-medium text-slate-200 mt-3">
-							Method 2: Reply STOP
-						</h3>
-						<p>
-							Reply <strong>STOP</strong> to any SMS message you receive from The Gathering Call. This will immediately opt you out of future SMS notifications.
-						</p>
-
-						<h3 className="text-base font-medium text-slate-200 mt-3">
-							Method 3: Contact Support
-						</h3>
-						<p>
-							Contact us through the platform&apos;s support channels and request to be removed from SMS notifications.
-						</p>
-
-						<p className="mt-3">
-							<strong>Note:</strong> After opting out, you will no longer receive SMS notifications, but you will still receive in-app messages through the internal messaging system.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							8. Help and Support
-						</h2>
-						<p>
-							If you have questions about SMS notifications, you can:
-						</p>
-						<ul className="list-disc list-inside space-y-2 ml-2">
-							<li>Reply <strong>HELP</strong> to any SMS message for assistance</li>
-							<li>Contact us through the platform&apos;s support channels</li>
-							<li>Review our <a href="/privacy" className="text-sky-400 hover:text-sky-300 underline">Privacy Policy</a> for more information about data handling</li>
-						</ul>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							9. Your Rights
-						</h2>
-						<p>
-							You have the right to:
-						</p>
-						<ul className="list-disc list-inside space-y-2 ml-2">
-							<li>Opt in or opt out of SMS notifications at any time</li>
-							<li>Request information about what phone number we have on file</li>
-							<li>Request deletion of your phone number from our records</li>
-							<li>Change your phone number at any time</li>
-							<li>Access all platform features without providing a phone number</li>
-						</ul>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							10. Changes to This Policy
-						</h2>
-						<p>
-							We may update this SMS Consent policy from time to time. When we make changes, we will update the &quot;Last updated&quot; date at the top of this page. Continued use of SMS notifications after changes indicates your acceptance of the updated terms.
-						</p>
-						<p>
-							If we make material changes to how we handle SMS notifications, we will notify you through the platform or via SMS before the changes take effect.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							11. Compliance
-						</h2>
-						<p>
-							Our SMS messaging program complies with:
-						</p>
-						<ul className="list-disc list-inside space-y-2 ml-2">
-							<li>Telephone Consumer Protection Act (TCPA)</li>
-							<li>CAN-SPAM Act</li>
-							<li>Cellular Telecommunications Industry Association (CTIA) guidelines</li>
-							<li>Mobile Marketing Association (MMA) Consumer Best Practices</li>
-						</ul>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							12. Contact Us
-						</h2>
-						<p>
-							If you have questions about SMS notifications or this consent policy, please contact us through the platform&apos;s support channels.
-						</p>
-					</div>
-				</div>
-			</div>
-		</section>
-	);
+                        <div className="rounded-2xl border border-indigo-500/40 bg-slate-900/70 p-8 shadow-xl">
+                                <h2 className="text-2xl font-semibold text-indigo-200">Control Your Experience</h2>
+                                <p className="mt-3 text-sm text-slate-300">
+                                        Use SMS for critical reminders, opt out whenever you like, and rely on in-app messaging for everything else. Your preferences always come first.
+                                </p>
+                                <div className="mt-6 flex flex-wrap items-center gap-4">
+                                        <Link
+                                                href="/profile"
+                                                className="rounded-lg bg-gradient-to-r from-amber-500 via-purple-500 to-indigo-500 px-5 py-2 text-sm font-semibold text-white transition hover:from-amber-400 hover:via-purple-400 hover:to-indigo-400"
+                                        >
+                                                Update Phone Number
+                                        </Link>
+                                        <Link
+                                                href="/support"
+                                                className="rounded-lg border border-white/10 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-white/30"
+                                        >
+                                                Contact Support
+                                        </Link>
+                                </div>
+                        </div>
+                </div>
+        );
 }

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -1,0 +1,170 @@
+import Link from "next/link";
+
+function LifebuoyIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <circle cx="12" cy="12" r="10" />
+                        <circle cx="12" cy="12" r="4" />
+                        <path d="m4.93 4.93 3.54 3.54" />
+                        <path d="m15.53 15.53 3.54 3.54" />
+                        <path d="m4.93 19.07 3.54-3.54" />
+                        <path d="m15.53 8.47 3.54-3.54" />
+                </svg>
+        );
+}
+
+function SparkIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <path d="M12 3v4" />
+                        <path d="M12 17v4" />
+                        <path d="M3 12h4" />
+                        <path d="M17 12h4" />
+                        <path d="m5.6 5.6 2.8 2.8" />
+                        <path d="m15.6 15.6 2.8 2.8" />
+                        <path d="m18.4 5.6-2.8 2.8" />
+                        <path d="m8.4 15.6-2.8 2.8" />
+                </svg>
+        );
+}
+
+function EnvelopeIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <path d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z" />
+                        <path d="m22 6-10 7L2 6" />
+                </svg>
+        );
+}
+
+const resourceLinks = [
+        { href: "/mission", label: "Our Mission" },
+        { href: "/terms", label: "Terms of Service" },
+        { href: "/privacy", label: "Privacy Policy" },
+        { href: "/technical-reference", label: "Technical Reference" },
+        { href: "/about-hosting-paid-games", label: "Paid Hosting Guide" },
+        { href: "/terms-paid-games", label: "Paid Games Terms" },
+        { href: "/sms-consent", label: "SMS Consent" },
+];
+
+export default function SupportPage() {
+        return (
+                <div className="mx-auto max-w-5xl space-y-8 py-8">
+                        <div className="rounded-3xl border-2 border-amber-500/50 bg-gradient-to-br from-amber-600/20 via-purple-600/20 to-indigo-600/20 p-8 shadow-2xl">
+                                <div className="text-center space-y-4">
+                                        <div className="flex justify-center gap-4">
+                                                <LifebuoyIcon className="h-8 w-8 text-amber-400" />
+                                                <SparkIcon className="h-8 w-8 text-purple-300" />
+                                                <EnvelopeIcon className="h-8 w-8 text-indigo-300" />
+                                        </div>
+                                        <h1 className="text-4xl font-bold bg-gradient-to-r from-amber-400 via-purple-400 to-indigo-400 bg-clip-text text-transparent">
+                                                Support Center
+                                        </h1>
+                                        <p className="text-slate-200 max-w-2xl mx-auto">
+                                                Find answers quickly, explore platform resources, and connect with our team whenever you need help.
+                                        </p>
+                                </div>
+                        </div>
+
+                        <section className="rounded-2xl border border-white/10 bg-slate-900/60 p-8 shadow-xl">
+                                <h2 className="text-2xl font-semibold text-amber-300">Self-Service Resources</h2>
+                                <p className="mt-3 text-sm text-slate-300">
+                                        Browse our guides and policy pages to learn how The Gathering Call supports Game Masters and players alike.
+                                </p>
+                                <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                                        {resourceLinks.map((link) => (
+                                                <Link
+                                                        key={link.href}
+                                                        href={link.href}
+                                                        className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm font-medium text-amber-100 transition hover:bg-amber-500/20"
+                                                >
+                                                        {link.label}
+                                                </Link>
+                                        ))}
+                                </div>
+                        </section>
+
+                        <section className="rounded-2xl border border-white/10 bg-slate-900/60 p-8 shadow-xl">
+                                <h2 className="text-2xl font-semibold text-purple-300">Community Support</h2>
+                                <p className="mt-3 text-sm text-slate-300">
+                                        Join our community server to get live help from The Gathering Call team and fellow GMs.
+                                </p>
+                                <div className="mt-6 flex flex-wrap gap-4">
+                                        <Link
+                                                href="https://discord.gg/Nx9jPfn6Sb"
+                                                className="rounded-lg border border-purple-500/40 bg-purple-500/10 px-5 py-2 text-sm font-semibold text-purple-100 transition hover:bg-purple-500/20"
+                                        >
+                                                Join the Discord Support Server
+                                        </Link>
+                                        <Link
+                                                href="https://discord.gg/Nx9jPfn6Sb"
+                                                className="rounded-lg border border-white/10 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-white/30"
+                                        >
+                                                Review Community Guidelines
+                                        </Link>
+                                </div>
+                        </section>
+
+                        <section className="rounded-2xl border border-white/10 bg-slate-900/60 p-8 shadow-xl">
+                                <h2 className="text-2xl font-semibold text-indigo-300">Need Direct Assistance?</h2>
+                                <div className="mt-6 grid gap-6 md:grid-cols-2">
+                                        <div className="rounded-xl border border-indigo-500/30 bg-indigo-500/10 p-5">
+                                                <h3 className="text-lg font-semibold text-indigo-100">Send Us a Message</h3>
+                                                <p className="mt-2 text-sm text-slate-100/80">
+                                                        Reach out from your in-app Messages by starting a conversation with our support team. We typically respond within one business day.
+                                                </p>
+                                                <Link
+                                                        href="/messages"
+                                                        className="mt-4 inline-flex items-center justify-center rounded-lg border border-indigo-500/40 bg-indigo-500/20 px-4 py-2 text-sm font-medium text-indigo-100 transition hover:bg-indigo-500/30"
+                                                >
+                                                        Open Messages
+                                                </Link>
+                                        </div>
+                                        <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-5">
+                                                <h3 className="text-lg font-semibold text-emerald-100">Email Our Team</h3>
+                                                <p className="mt-2 text-sm text-slate-100/80">
+                                                        Prefer email? Contact us at <a className="text-emerald-100 underline decoration-emerald-300/60 underline-offset-4 transition hover:text-emerald-50" href="mailto:support@thegatheringcall.com">support@thegatheringcall.com</a> for billing, account, or policy questions.
+                                                </p>
+                                        </div>
+                                </div>
+                        </section>
+
+                        <section className="rounded-2xl border-2 border-amber-500/50 bg-gradient-to-br from-amber-600/20 via-purple-600/20 to-indigo-600/20 p-8 text-center shadow-2xl">
+                                <h2 className="text-2xl font-semibold text-slate-100">We&apos;re Here to Help</h2>
+                                <p className="mt-3 text-sm text-slate-200 max-w-2xl mx-auto">
+                                        Whether you&apos;re launching a new campaign, exploring paid games, or joining your first session, our team is ready to support your journey on The Gathering Call.
+                                </p>
+                        </section>
+                </div>
+        );
+}

--- a/app/terms-paid-games/page.tsx
+++ b/app/terms-paid-games/page.tsx
@@ -4,235 +4,251 @@ import { useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
+function CoinIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <circle cx="12" cy="12" r="9" />
+                        <path d="M8 12h8" />
+                        <path d="M12 8v8" />
+                </svg>
+        );
+}
+
+function ContractIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <path d="M7 2h10a2 2 0 0 1 2 2v16l-4-3-4 3-4-3-4 3V4a2 2 0 0 1 2-2z" />
+                        <path d="M9 7h6" />
+                        <path d="M9 11h6" />
+                </svg>
+        );
+}
+
+function SparklesIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <path d="M12 3v4" />
+                        <path d="M12 17v4" />
+                        <path d="M3 12h4" />
+                        <path d="M17 12h4" />
+                        <path d="m5 5 3 3" />
+                        <path d="m16 16 3 3" />
+                        <path d="m16 5 3 3" />
+                        <path d="m5 16 3 3" />
+                </svg>
+        );
+}
+
 function PaidGamesTermsContent() {
-	const router = useRouter();
-	const searchParams = useSearchParams();
-	const [accepted, setAccepted] = useState(false);
-	const [isSubmitting, setIsSubmitting] = useState(false);
-	const [error, setError] = useState("");
-	const fromSettings = searchParams.get("from") === "settings";
+        const router = useRouter();
+        const searchParams = useSearchParams();
+        const [accepted, setAccepted] = useState(false);
+        const [isSubmitting, setIsSubmitting] = useState(false);
+        const [error, setError] = useState("");
+        const fromSettings = searchParams.get("from") === "settings";
 
-	const handleAccept = async () => {
-		if (!accepted) {
-			setError("You must accept the terms and conditions to continue");
-			return;
-		}
+        const handleAccept = async () => {
+                if (!accepted) {
+                        setError("You must accept the terms and conditions to continue");
+                        return;
+                }
 
-		setIsSubmitting(true);
-		setError("");
+                setIsSubmitting(true);
+                setError("");
 
-		try {
-			const response = await fetch("/api/profile/enable-paid-games", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-				},
-			});
+                try {
+                        const response = await fetch("/api/profile/enable-paid-games", {
+                                method: "POST",
+                                headers: {
+                                        "Content-Type": "application/json",
+                                },
+                        });
 
-			if (!response.ok) {
-				const errorData = await response.json();
-				throw new Error(errorData.error || "Failed to enable paid games");
-			}
+                        if (!response.ok) {
+                                const errorData = await response.json();
+                                throw new Error(errorData.error || "Failed to enable paid games");
+                        }
 
-			// Redirect to settings or profile page
-			router.push(fromSettings ? "/settings" : "/profile");
-		} catch (err) {
-			setError(
-				err instanceof Error ? err.message : "Failed to enable paid games"
-			);
-		} finally {
-			setIsSubmitting(false);
-		}
-	};
+                        router.push(fromSettings ? "/settings" : "/profile");
+                } catch (err) {
+                        setError(
+                                err instanceof Error ? err.message : "Failed to enable paid games"
+                        );
+                } finally {
+                        setIsSubmitting(false);
+                }
+        };
 
-	return (
-		<section className="space-y-6">
-			<div>
-				<h1 className="text-2xl font-semibold text-slate-100">
-					Paid Games Terms and Conditions
-				</h1>
-				<p className="mt-2 text-sm text-slate-400">
-					Please read and accept these terms to enable posting paid
-					campaigns.
-				</p>
-			</div>
+        return (
+                <div className="mx-auto max-w-5xl space-y-8 py-8">
+                        <div className="rounded-3xl border-2 border-amber-500/50 bg-gradient-to-br from-amber-600/20 via-purple-600/20 to-indigo-600/20 p-8 shadow-2xl">
+                                <div className="text-center space-y-4">
+                                        <div className="flex justify-center gap-4">
+                                                <CoinIcon className="h-8 w-8 text-amber-400" />
+                                                <ContractIcon className="h-8 w-8 text-purple-200" />
+                                                <SparklesIcon className="h-8 w-8 text-indigo-300" />
+                                        </div>
+                                        <h1 className="text-4xl font-bold bg-gradient-to-r from-amber-400 via-purple-400 to-indigo-400 bg-clip-text text-transparent">
+                                                Paid Games Terms &amp; Conditions
+                                        </h1>
+                                        <p className="text-slate-200 max-w-2xl mx-auto">
+                                                Understand the program, confirm the expectations, and unlock paid campaigns with confidence.
+                                        </p>
+                                </div>
+                        </div>
 
-			<div className="space-y-4 rounded-2xl border border-slate-800/60 bg-slate-900/40 p-6 shadow-lg shadow-slate-900/30">
-				<div className="space-y-4 text-sm text-slate-300 leading-relaxed">
-					<h2 className="text-lg font-semibold text-slate-100">
-						Terms of Service for Paid Games
-					</h2>
+                        <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+                                <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-8 shadow-xl">
+                                        <div className="space-y-6 text-sm leading-relaxed text-slate-300">
+                                                <h2 className="text-2xl font-semibold text-amber-300">Program Overview</h2>
+                                                <div className="space-y-4">
+                                                        <div>
+                                                                <h3 className="text-base font-semibold text-slate-100">1. Payment Processing</h3>
+                                                                <p>
+                                                                        All payments for paid game sessions are processed securely through Stripe. By enabling paid games, you agree to Stripe&apos;s terms of service and authorize us to process payments on your behalf.
+                                                                </p>
+                                                        </div>
+                                                        <div>
+                                                                <h3 className="text-base font-semibold text-slate-100">2. Platform Fee</h3>
+                                                                <p>
+                                                                        <strong className="text-slate-100">The platform operator will retain 15% of each paid game fee.</strong> The remaining 85% will be paid to you (the game host) after deducting payment processing fees.
+                                                                </p>
+                                                                <p className="text-xs text-slate-400">
+                                                                        Example: Charging $10 per session results in a $1.50 platform fee. After Stripe&apos;s $0.30 + 2.9% processing fee, you receive approximately $7.91.
+                                                                </p>
+                                                        </div>
+                                                        <div>
+                                                                <h3 className="text-base font-semibold text-slate-100">3. Host Responsibilities</h3>
+                                                                <ul className="list-disc list-inside space-y-2 text-slate-200/80">
+                                                                        <li>Provide the game sessions as advertised and agreed upon with players</li>
+                                                                        <li>Maintain professional conduct and deliver a quality gaming experience</li>
+                                                                        <li>Honor all scheduled sessions or offer appropriate refunds</li>
+                                                                        <li>Communicate clearly with players about session details, requirements, and changes</li>
+                                                                </ul>
+                                                        </div>
+                                                        <div>
+                                                                <h3 className="text-base font-semibold text-slate-100">4. Refund Policy</h3>
+                                                                <p>
+                                                                        Refunds are at the discretion of the game host and must be processed through the platform. Hosts are expected to provide refunds for canceled or undelivered sessions. Repeated refund requests or payment disputes may result in suspension of paid game privileges.
+                                                                </p>
+                                                        </div>
+                                                        <div>
+                                                                <h3 className="text-base font-semibold text-slate-100">5. Compliance and Tax Obligations</h3>
+                                                                <p>
+                                                                        You are responsible for complying with all applicable laws and regulations, including reporting income and paying taxes on earnings from paid game sessions. The platform will provide necessary tax documentation as required by law.
+                                                                </p>
+                                                        </div>
+                                                        <div>
+                                                                <h3 className="text-base font-semibold text-slate-100">6. Account Suspension</h3>
+                                                                <p>
+                                                                        The platform reserves the right to suspend or revoke paid game privileges for violations of these terms, fraud, excessive disputes, or conduct that harms the community or platform reputation.
+                                                                </p>
+                                                        </div>
+                                                        <div>
+                                                                <h3 className="text-base font-semibold text-slate-100">7. Changes to Terms</h3>
+                                                                <p>
+                                                                        These terms may be updated from time to time. Continued use of paid game features after changes constitutes acceptance of the updated terms. You will be notified of significant changes via email or platform notification.
+                                                                </p>
+                                                        </div>
+                                                </div>
+                                        </div>
+                                </div>
 
-					<div className="space-y-3">
-						<h3 className="text-base font-medium text-slate-200">
-							1. Payment Processing
-						</h3>
-						<p>
-							All payments for paid game sessions are processed securely
-							through Stripe. By enabling paid games, you agree to
-							Stripe&apos;s terms of service and authorize us to process
-							payments on your behalf.
-						</p>
-					</div>
+                                <div className="space-y-6">
+                                        <div className="rounded-2xl border border-indigo-500/40 bg-slate-900/70 p-6 shadow-xl">
+                                                <h3 className="text-lg font-semibold text-indigo-200">Enable Paid Games</h3>
+                                                <p className="mt-2 text-sm text-slate-300">
+                                                        Confirm you understand the program details to unlock zero-hassle payments and promote professional sessions.
+                                                </p>
+                                                <div className="mt-4 flex items-start gap-3">
+                                                        <input
+                                                                type="checkbox"
+                                                                checked={accepted}
+                                                                onChange={(event) => setAccepted(event.target.checked)}
+                                                                className="mt-1 h-5 w-5 rounded border-white/20 bg-slate-950 text-indigo-400 focus:ring-2 focus:ring-indigo-400/60"
+                                                        />
+                                                        <span className="text-sm text-slate-200">
+                                                                I have read and agree to the Paid Games Terms and Conditions, including the 15% platform fee on all paid game sessions.
+                                                        </span>
+                                                </div>
+                                                {error ? (
+                                                        <div className="mt-4 rounded-lg border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-100">
+                                                                {error}
+                                                        </div>
+                                                ) : null}
+                                                <div className="mt-6 flex flex-col gap-3">
+                                                        <button
+                                                                type="button"
+                                                                onClick={handleAccept}
+                                                                disabled={!accepted || isSubmitting}
+                                                                className="rounded-lg bg-gradient-to-r from-amber-500 via-purple-500 to-indigo-500 px-4 py-3 text-sm font-semibold text-white transition hover:from-amber-400 hover:via-purple-400 hover:to-indigo-400 disabled:cursor-not-allowed disabled:opacity-70"
+                                                        >
+                                                                {isSubmitting ? "Processing..." : "Accept and Enable Paid Games"}
+                                                        </button>
+                                                        <Link
+                                                                href={fromSettings ? "/settings" : "/profile"}
+                                                                className="rounded-lg border border-white/10 px-4 py-3 text-center text-sm font-medium text-slate-200 transition hover:border-white/30"
+                                                        >
+                                                                Cancel
+                                                        </Link>
+                                                </div>
+                                        </div>
 
-					<div className="space-y-3">
-						<h3 className="text-base font-medium text-slate-200">
-							2. Platform Fee
-						</h3>
-						<p>
-							<strong className="text-slate-100">
-								The platform operator will retain 15% of each paid game
-								fee.
-							</strong>{" "}
-							The remaining 85% will be paid to you (the game host) after
-							deducting payment processing fees.
-						</p>
-						<p className="text-slate-400 text-xs">
-							Example: If you charge $10 per session, the platform will
-							retain $1.50 and you will receive the remainder, minus
-							payment processing fees. Stripe&apos;s fee is $0.30 + 2.9%
-							per transaction, you would receive approximately $7.91 per
-							session.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h3 className="text-base font-medium text-slate-200">
-							3. Host Responsibilities
-						</h3>
-						<ul className="list-disc list-inside space-y-2 ml-2">
-							<li>
-								You must provide the game sessions as advertised and
-								agreed upon with players
-							</li>
-							<li>
-								You are responsible for maintaining professional conduct
-								and providing a quality gaming experience
-							</li>
-							<li>
-								You must honor all scheduled sessions or provide
-								appropriate refunds
-							</li>
-							<li>
-								You agree to communicate clearly with players about
-								session details, requirements, and any changes
-							</li>
-						</ul>
-					</div>
-
-					<div className="space-y-3">
-						<h3 className="text-base font-medium text-slate-200">
-							4. Refund Policy
-						</h3>
-						<p>
-							Refunds are at the discretion of the game host and must be
-							processed through the platform. Hosts are expected to
-							provide refunds for canceled or undelivered sessions.
-							Repeated refund requests or payment disputes may result in
-							suspension of paid game privileges.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h3 className="text-base font-medium text-slate-200">
-							5. Compliance and Tax Obligations
-						</h3>
-						<p>
-							You are responsible for complying with all applicable laws
-							and regulations, including reporting income and paying
-							taxes on earnings from paid game sessions. The platform
-							will provide necessary tax documentation as required by
-							law.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h3 className="text-base font-medium text-slate-200">
-							6. Account Suspension
-						</h3>
-						<p>
-							The platform reserves the right to suspend or revoke paid
-							game privileges for violations of these terms, fraud,
-							excessive disputes, or conduct that harms the community or
-							platform reputation.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h3 className="text-base font-medium text-slate-200">
-							7. Changes to Terms
-						</h3>
-						<p>
-							These terms may be updated from time to time. Continued use
-							of paid game features after changes constitutes acceptance
-							of the updated terms. You will be notified of significant
-							changes via email or platform notification.
-						</p>
-					</div>
-				</div>
-
-				<div className="mt-6 pt-6 border-t border-slate-800">
-					<label className="flex items-start gap-3 cursor-pointer">
-						<input
-							type="checkbox"
-							checked={accepted}
-							onChange={(e) => setAccepted(e.target.checked)}
-							className="mt-1 h-5 w-5 rounded border-slate-700 bg-slate-950/60 text-sky-500 focus:ring-2 focus:ring-sky-500/40"
-						/>
-						<span className="text-sm text-slate-300">
-							I have read and agree to the Paid Games Terms and
-							Conditions, including the 15% platform fee on all paid game
-							sessions.
-						</span>
-					</label>
-				</div>
-
-				{error && (
-					<div className="rounded-lg bg-red-900/20 border border-red-800 p-3">
-						<p className="text-sm text-red-200">{error}</p>
-					</div>
-				)}
-
-				<div className="flex gap-3">
-					<button
-						type="button"
-						onClick={handleAccept}
-						disabled={!accepted || isSubmitting}
-						className="flex-1 rounded-xl bg-sky-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-50"
-					>
-						{isSubmitting
-							? "Processing..."
-							: "Accept and Enable Paid Games"}
-					</button>
-					<Link
-						href={fromSettings ? "/settings" : "/profile"}
-						className="rounded-xl border border-slate-700 bg-slate-900 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-slate-500 text-center"
-					>
-						Cancel
-					</Link>
-				</div>
-			</div>
-		</section>
-	);
+                                        <div className="rounded-2xl border border-amber-500/40 bg-amber-500/10 p-6 shadow-xl">
+                                                <h3 className="text-lg font-semibold text-amber-200">Need help first?</h3>
+                                                <p className="mt-2 text-sm text-amber-100/80">
+                                                        Review best practices in our <Link href="/about-hosting-paid-games" className="text-amber-100 underline decoration-amber-300/60 underline-offset-4 transition hover:text-amber-50">paid hosting guide</Link> or reach out to <Link href="/support" className="text-amber-100 underline decoration-amber-300/60 underline-offset-4 transition hover:text-amber-50">support</Link> before enabling payments.
+                                                </p>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        );
 }
 
 export default function PaidGamesTermsPage() {
-	return (
-		<Suspense
-			fallback={
-				<section className="space-y-6">
-					<div>
-						<h1 className="text-2xl font-semibold text-slate-100">
-							Paid Games Terms and Conditions
-						</h1>
-						<p className="mt-2 text-sm text-slate-400">
-							Loading terms and conditions...
-						</p>
-					</div>
-				</section>
-			}
-		>
-			<PaidGamesTermsContent />
-		</Suspense>
-	);
+        return (
+                <Suspense
+                        fallback={
+                                <div className="mx-auto max-w-3xl space-y-4 py-8">
+                                        <div className="rounded-3xl border-2 border-amber-500/40 bg-gradient-to-r from-amber-500/10 via-purple-500/10 to-indigo-500/10 p-8 text-center shadow-2xl">
+                                                <h1 className="text-3xl font-semibold text-slate-100">Paid Games Terms &amp; Conditions</h1>
+                                                <p className="mt-3 text-sm text-slate-300">Loading terms and conditions...</p>
+                                        </div>
+                                </div>
+                        }
+                >
+                        <PaidGamesTermsContent />
+                </Suspense>
+        );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,198 +1,323 @@
+import Link from "next/link";
+
+function ScaleIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <path d="M7 21h10" />
+                        <path d="M12 3v18" />
+                        <path d="m3 6 3 6 3-6" />
+                        <path d="m15 6 3 6 3-6" />
+                </svg>
+        );
+}
+
+function BookIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <path d="M3 4h6a3 3 0 0 1 3 3v13a2 2 0 0 0-2-2H3z" />
+                        <path d="M21 4h-6a3 3 0 0 0-3 3v13a2 2 0 0 1 2-2h7z" />
+                </svg>
+        );
+}
+
+function ShieldIcon({ className }: { className?: string }) {
+        return (
+                <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={className}
+                        aria-hidden="true"
+                >
+                        <path d="M12 2 4 5v6c0 5.25 3.43 10.39 8 12 4.57-1.61 8-6.75 8-12V5z" />
+                        <path d="M9 12h6" />
+                        <path d="M12 9v6" />
+                </svg>
+        );
+}
+
+const sections = [
+        {
+                title: "1. Acceptance of Terms",
+                content: (
+                        <p>
+                                By accessing and using The Gathering Call platform, you accept and agree to be bound by the terms and provision of this agreement. If you do not agree to abide by the above, please do not use this service.
+                        </p>
+                ),
+        },
+        {
+                title: "2. Use License",
+                content: (
+                        <>
+                                <p>
+                                        Permission is granted to temporarily use The Gathering Call for personal, non-commercial use only. This is the grant of a license, not a transfer of title, and under this license you may not:
+                                </p>
+                                <ul className="list-disc list-inside space-y-2 text-slate-200/80">
+                                        <li>Modify or copy the materials</li>
+                                        <li>Use the materials for any commercial purpose or for any public display</li>
+                                        <li>Attempt to reverse engineer any software contained on the platform</li>
+                                        <li>Remove any copyright or other proprietary notations from the materials</li>
+                                        <li>Transfer the materials to another person or &quot;mirror&quot; the materials on any other server</li>
+                                </ul>
+                        </>
+                ),
+        },
+        {
+                title: "3. User Accounts",
+                content: (
+                        <>
+                                <p>
+                                        When you create an account with us, you must provide information that is accurate, complete, and current at all times. Failure to do so constitutes a breach of the Terms, which may result in immediate termination of your account on our Service.
+                                </p>
+                                <p>
+                                        You are responsible for safeguarding the password that you use to access the Service and for any activities or actions under your password.
+                                </p>
+                        </>
+                ),
+        },
+        {
+                title: "4. User Content",
+                content: (
+                        <>
+                                <p>
+                                        Our Service allows you to post, link, store, share and otherwise make available certain information, text, graphics, or other material. You are responsible for the content that you post on or through the Service, including its legality, reliability, and appropriateness.
+                                </p>
+                                <p>
+                                        By posting content on or through the Service, you grant us the right and license to use, modify, publicly perform, publicly display, reproduce, and distribute such content on and through the Service.
+                                </p>
+                        </>
+                ),
+        },
+        {
+                title: "5. Third-Party Services and BoardGameGeek Integration",
+                content: (
+                        <>
+                                <p>
+                                        The Gathering Call uses BoardGameGeek&apos;s XML API2 (BGG API2) to provide enhanced features and functionality. By using our Service, you acknowledge and agree to the following:
+                                </p>
+                                <ul className="list-disc list-inside space-y-2 text-slate-200/80">
+                                        <li>
+                                                <strong className="text-slate-100">User Profile Integration:</strong> We use BGG API2 to allow you to link your BoardGameGeek username and profile to your account on The Gathering Call
+                                        </li>
+                                        <li>
+                                                <strong className="text-slate-100">Collection Integration:</strong> When you provide your BGG username, we access your BoardGameGeek collection data through their API to display your game library and preferences
+                                        </li>
+                                        <li>
+                                                <strong className="text-slate-100">Marketplace:</strong> Our marketplace feature is powered by BoardGameGeek&apos;s game database and marketplace listings accessed through BGG API2
+                                        </li>
+                                        <li>
+                                                <strong className="text-slate-100">Game Library:</strong> Game search and library features use BoardGameGeek&apos;s comprehensive game database accessed through their API
+                                        </li>
+                                </ul>
+                                <p>
+                                        When you link your BoardGameGeek username or access features powered by BGG API2, you are also subject to BoardGameGeek&apos;s own terms of service and privacy policy. We are not responsible for BoardGameGeek&apos;s services, data accuracy, or availability. BoardGameGeek is a third-party service independent of The Gathering Call.
+                                </p>
+                                <p>
+                                        BoardGameGeek, its trademarks, service marks, and logos are the property of BoardGameGeek, LLC. All rights reserved.
+                                </p>
+                        </>
+                ),
+        },
+        {
+                title: "6. Prohibited Uses",
+                content: (
+                        <>
+                                <p>
+                                        You may use the Service only for lawful purposes and in accordance with these Terms. You agree not to use the Service:
+                                </p>
+                                <ul className="list-disc list-inside space-y-2 text-slate-200/80">
+                                        <li>In any way that violates any applicable national or international law or regulation</li>
+                                        <li>To transmit, or procure the sending of, any advertising or promotional material, including any &quot;junk mail&quot;, &quot;chain letter,&quot; &quot;spam,&quot; or any other similar solicitation</li>
+                                        <li>To impersonate or attempt to impersonate the Company, a Company employee, another user, or any other person or entity</li>
+                                        <li>In any way that infringes upon the rights of others, or in any way is illegal, threatening, fraudulent, or harmful</li>
+                                        <li>To engage in any other conduct that restricts or inhibits anyone&apos;s use or enjoyment of the Service</li>
+                                </ul>
+                        </>
+                ),
+        },
+        {
+                title: "7. Non-Discrimination and Community Standards",
+                content: (
+                        <>
+                                <p>
+                                        The Gathering Call is committed to maintaining an inclusive and welcoming community for all users. We have zero tolerance for discrimination or harassment of any kind.
+                                </p>
+                                <p>
+                                        Discrimination, harassment, or abusive behavior directed at any user based on the following characteristics is strictly prohibited:
+                                </p>
+                                <ul className="list-disc list-inside space-y-2 text-slate-200/80">
+                                        <li>Race, ethnicity, or national origin</li>
+                                        <li>Religion or religious beliefs</li>
+                                        <li>Sex, gender, or gender identity</li>
+                                        <li>Sexual orientation</li>
+                                        <li>Physical appearance or body size</li>
+                                        <li>Disability or medical condition</li>
+                                        <li>Age</li>
+                                        <li>Veteran status</li>
+                                        <li>Any other protected characteristic under applicable law</li>
+                                </ul>
+                                <p>
+                                        Violations of this policy will result in immediate termination of your account and permanent ban from the Service. We reserve the right to take additional legal action as appropriate.
+                                </p>
+                        </>
+                ),
+        },
+        {
+                title: "8. Termination",
+                content: (
+                        <>
+                                <p>
+                                        We may terminate or suspend your account and bar access to the Service immediately, without prior notice or liability, under our sole discretion, for any reason whatsoever and without limitation, including but not limited to a breach of the Terms.
+                                </p>
+                                <p>
+                                        If you wish to terminate your account, you may simply discontinue using the Service or contact us to request account deletion.
+                                </p>
+                        </>
+                ),
+        },
+        {
+                title: "9. Limitation of Liability",
+                content: (
+                        <p>
+                                In no event shall The Gathering Call, nor its directors, employees, partners, agents, suppliers, or affiliates, be liable for any indirect, incidental, special, consequential or punitive damages, including without limitation, loss of profits, data, use, goodwill, or other intangible losses, resulting from your access to or use of or inability to access or use the Service.
+                        </p>
+                ),
+        },
+        {
+                title: "10. Disclaimer",
+                content: (
+                        <p>
+                                Your use of the Service is at your sole risk. The Service is provided on an &quot;AS IS&quot; and &quot;AS AVAILABLE&quot; basis. The Service is provided without warranties of any kind, whether express or implied, including, but not limited to, implied warranties of merchantability, fitness for a particular purpose, non-infringement or course of performance.
+                        </p>
+                ),
+        },
+        {
+                title: "11. Governing Law",
+                content: (
+                        <p>
+                                These Terms shall be governed and construed in accordance with the laws of the jurisdiction in which The Gathering Call operates, without regard to its conflict of law provisions.
+                        </p>
+                ),
+        },
+        {
+                title: "12. Changes to Terms",
+                content: (
+                        <>
+                                <p>
+                                        We reserve the right, at our sole discretion, to modify or replace these Terms at any time. If a revision is material, we will provide at least 30 days notice prior to any new terms taking effect. What constitutes a material change will be determined at our sole discretion.
+                                </p>
+                                <p>
+                                        By continuing to access or use our Service after any revisions become effective, you agree to be bound by the revised terms. If you do not agree to the new terms, you are no longer authorized to use the Service.
+                                </p>
+                        </>
+                ),
+        },
+        {
+                title: "13. Contact Us",
+                content: (
+                        <p>
+                                If you have any questions about these Terms, please contact us through the platform&apos;s support channels.
+                        </p>
+                ),
+        },
+];
+
 export default function TermsPage() {
-	return (
-		<section className="space-y-6">
-			<div>
-				<h1 className="text-2xl font-semibold text-slate-100">
-					Terms of Service
-				</h1>
-				<p className="mt-2 text-sm text-slate-400">
-					Last updated: {new Date().toLocaleDateString()}
-				</p>
-			</div>
+        const lastUpdated = new Date().toLocaleDateString();
 
-			<div className="space-y-4 rounded-2xl border border-slate-800/60 bg-slate-900/40 p-6 shadow-lg shadow-slate-900/30">
-				<div className="space-y-4 text-sm text-slate-300 leading-relaxed">
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							1. Acceptance of Terms
-						</h2>
-						<p>
-							By accessing and using The Gathering Call platform, you accept and agree to be bound by the terms and provision of this agreement. If you do not agree to abide by the above, please do not use this service.
-						</p>
-					</div>
+        return (
+                <div className="mx-auto max-w-5xl space-y-8 py-8">
+                        <div className="rounded-3xl border-2 border-amber-500/50 bg-gradient-to-br from-amber-600/20 via-purple-600/20 to-indigo-600/20 p-8 shadow-2xl">
+                                <div className="text-center space-y-4">
+                                        <div className="flex justify-center gap-4">
+                                                <ScaleIcon className="h-8 w-8 text-amber-400" />
+                                                <BookIcon className="h-8 w-8 text-purple-300" />
+                                                <ShieldIcon className="h-8 w-8 text-indigo-300" />
+                                        </div>
+                                        <h1 className="text-4xl font-bold bg-gradient-to-r from-amber-400 via-purple-400 to-indigo-400 bg-clip-text text-transparent">
+                                                Terms of Service
+                                        </h1>
+                                        <p className="text-slate-200">
+                                                Clear guidelines that keep The Gathering Call safe, fair, and community driven.
+                                        </p>
+                                        <div className="inline-flex items-center gap-2 rounded-full border border-amber-500/50 bg-amber-500/20 px-5 py-2 text-sm font-semibold text-amber-200">
+                                                Last updated: {lastUpdated}
+                                        </div>
+                                </div>
+                        </div>
 
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							2. Use License
-						</h2>
-						<p>
-							Permission is granted to temporarily use The Gathering Call for personal, non-commercial use only. This is the grant of a license, not a transfer of title, and under this license you may not:
-						</p>
-						<ul className="list-disc list-inside space-y-2 ml-2">
-							<li>Modify or copy the materials</li>
-							<li>Use the materials for any commercial purpose or for any public display</li>
-							<li>Attempt to reverse engineer any software contained on the platform</li>
-							<li>Remove any copyright or other proprietary notations from the materials</li>
-							<li>Transfer the materials to another person or &quot;mirror&quot; the materials on any other server</li>
-						</ul>
-					</div>
+                        <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-8 shadow-xl">
+                                <div className="space-y-8 text-sm leading-relaxed text-slate-300">
+                                        {sections.map((section) => (
+                                                <div key={section.title} className="space-y-3">
+                                                        <h2 className="text-xl font-semibold text-slate-100">{section.title}</h2>
+                                                        <div className="space-y-3">{section.content}</div>
+                                                </div>
+                                        ))}
+                                </div>
+                        </div>
 
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							3. User Accounts
-						</h2>
-						<p>
-							When you create an account with us, you must provide information that is accurate, complete, and current at all times. Failure to do so constitutes a breach of the Terms, which may result in immediate termination of your account on our Service.
-						</p>
-						<p>
-							You are responsible for safeguarding the password that you use to access the Service and for any activities or actions under your password.
-						</p>
-					</div>
+                        <div className="rounded-2xl border border-indigo-500/40 bg-slate-900/60 p-8 shadow-xl">
+                                <div className="grid gap-6 md:grid-cols-2">
+                                        <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-6">
+                                                <h3 className="text-lg font-semibold text-amber-200">Hosting with Confidence</h3>
+                                                <p className="mt-2 text-sm text-amber-100/80">
+                                                        Game Masters benefit from transparent policies that outline expectations, protect your communities, and highlight the value you bring to every session.
+                                                </p>
+                                        </div>
+                                        <div className="rounded-xl border border-purple-500/40 bg-purple-500/10 p-6">
+                                                <h3 className="text-lg font-semibold text-purple-200">Players Come First</h3>
+                                                <p className="mt-2 text-sm text-purple-100/80">
+                                                        Players enjoy safe, inclusive spaces with clear standards for conduct, communication, and dispute resolution across the platform.
+                                                </p>
+                                        </div>
+                                </div>
+                        </div>
 
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							4. User Content
-						</h2>
-						<p>
-							Our Service allows you to post, link, store, share and otherwise make available certain information, text, graphics, or other material. You are responsible for the content that you post on or through the Service, including its legality, reliability, and appropriateness.
-						</p>
-						<p>
-							By posting content on or through the Service, you grant us the right and license to use, modify, publicly perform, publicly display, reproduce, and distribute such content on and through the Service.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							5. Third-Party Services and BoardGameGeek Integration
-						</h2>
-						<p>
-							The Gathering Call uses BoardGameGeek&apos;s XML API2 (BGG API2) to provide enhanced features and functionality. By using our Service, you acknowledge and agree to the following:
-						</p>
-						<ul className="list-disc list-inside space-y-2 ml-2">
-							<li>
-								<strong>User Profile Integration:</strong> We use BGG API2 to allow you to link your BoardGameGeek username and profile to your account on The Gathering Call
-							</li>
-							<li>
-								<strong>Collection Integration:</strong> When you provide your BGG username, we access your BoardGameGeek collection data through their API to display your game library and preferences
-							</li>
-							<li>
-								<strong>Marketplace:</strong> Our marketplace feature is powered by BoardGameGeek&apos;s game database and marketplace listings accessed through BGG API2
-							</li>
-							<li>
-								<strong>Game Library:</strong> Game search and library features use BoardGameGeek&apos;s comprehensive game database accessed through their API
-							</li>
-						</ul>
-						<p>
-							When you link your BoardGameGeek username or access features powered by BGG API2, you are also subject to BoardGameGeek&apos;s own terms of service and privacy policy. We are not responsible for BoardGameGeek&apos;s services, data accuracy, or availability. BoardGameGeek is a third-party service independent of The Gathering Call.
-						</p>
-						<p>
-							BoardGameGeek, its trademarks, service marks, and logos are the property of BoardGameGeek, LLC. All rights reserved.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							6. Prohibited Uses
-						</h2>
-						<p>
-							You may use the Service only for lawful purposes and in accordance with these Terms. You agree not to use the Service:
-						</p>
-						<ul className="list-disc list-inside space-y-2 ml-2">
-							<li>In any way that violates any applicable national or international law or regulation</li>
-							<li>To transmit, or procure the sending of, any advertising or promotional material, including any &quot;junk mail&quot;, &quot;chain letter,&quot; &quot;spam,&quot; or any other similar solicitation</li>
-							<li>To impersonate or attempt to impersonate the Company, a Company employee, another user, or any other person or entity</li>
-							<li>In any way that infringes upon the rights of others, or in any way is illegal, threatening, fraudulent, or harmful</li>
-							<li>To engage in any other conduct that restricts or inhibits anyone&apos;s use or enjoyment of the Service</li>
-						</ul>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							7. Non-Discrimination and Community Standards
-						</h2>
-						<p>
-							The Gathering Call is committed to maintaining an inclusive and welcoming community for all users. We have zero tolerance for discrimination or harassment of any kind.
-						</p>
-						<p>
-							Discrimination, harassment, or abusive behavior directed at any user based on the following characteristics is strictly prohibited:
-						</p>
-						<ul className="list-disc list-inside space-y-2 ml-2">
-							<li>Race, ethnicity, or national origin</li>
-							<li>Religion or religious beliefs</li>
-							<li>Sex, gender, or gender identity</li>
-							<li>Sexual orientation</li>
-							<li>Physical appearance or body size</li>
-							<li>Disability or medical condition</li>
-							<li>Age</li>
-							<li>Veteran status</li>
-							<li>Any other protected characteristic under applicable law</li>
-						</ul>
-						<p>
-							Violations of this policy will result in immediate termination of your account and permanent ban from the Service. We reserve the right to take additional legal action as appropriate.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							8. Termination
-						</h2>
-						<p>
-							We may terminate or suspend your account and bar access to the Service immediately, without prior notice or liability, under our sole discretion, for any reason whatsoever and without limitation, including but not limited to a breach of the Terms.
-						</p>
-						<p>
-							If you wish to terminate your account, you may simply discontinue using the Service or contact us to request account deletion.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							9. Limitation of Liability
-						</h2>
-						<p>
-							In no event shall The Gathering Call, nor its directors, employees, partners, agents, suppliers, or affiliates, be liable for any indirect, incidental, special, consequential or punitive damages, including without limitation, loss of profits, data, use, goodwill, or other intangible losses, resulting from your access to or use of or inability to access or use the Service.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							10. Disclaimer
-						</h2>
-						<p>
-							Your use of the Service is at your sole risk. The Service is provided on an &quot;AS IS&quot; and &quot;AS AVAILABLE&quot; basis. The Service is provided without warranties of any kind, whether express or implied, including, but not limited to, implied warranties of merchantability, fitness for a particular purpose, non-infringement or course of performance.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							11. Governing Law
-						</h2>
-						<p>
-							These Terms shall be governed and construed in accordance with the laws of the jurisdiction in which The Gathering Call operates, without regard to its conflict of law provisions.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							12. Changes to Terms
-						</h2>
-						<p>
-							We reserve the right, at our sole discretion, to modify or replace these Terms at any time. If a revision is material, we will provide at least 30 days notice prior to any new terms taking effect. What constitutes a material change will be determined at our sole discretion.
-						</p>
-						<p>
-							By continuing to access or use our Service after any revisions become effective, you agree to be bound by the revised terms. If you do not agree to the new terms, you are no longer authorized to use the Service.
-						</p>
-					</div>
-
-					<div className="space-y-3">
-						<h2 className="text-lg font-semibold text-slate-100">
-							13. Contact Us
-						</h2>
-						<p>
-							If you have any questions about these Terms, please contact us through the platform&apos;s support channels.
-						</p>
-					</div>
-				</div>
-			</div>
-		</section>
-	);
+                        <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-8 shadow-xl text-center">
+                                <h2 className="text-2xl font-semibold text-slate-100">Need a hand?</h2>
+                                <p className="mt-3 text-sm text-slate-300">
+                                        Our support team is here to help with policy questions, account concerns, or anything else you need to keep your adventures running smoothly.
+                                </p>
+                                <div className="mt-6 flex flex-wrap items-center justify-center gap-4">
+                                        <Link
+                                                href="/support"
+                                                className="rounded-lg border border-amber-500/50 bg-amber-500/20 px-5 py-2 text-sm font-medium text-amber-200 transition hover:bg-amber-500/30"
+                                        >
+                                                Visit Support Center
+                                        </Link>
+                                        <Link
+                                                href="https://discord.gg/Nx9jPfn6Sb"
+                                                className="rounded-lg border border-indigo-500/50 bg-indigo-500/20 px-5 py-2 text-sm font-medium text-indigo-200 transition hover:bg-indigo-500/30"
+                                        >
+                                                Join Our Discord
+                                        </Link>
+                                </div>
+                        </div>
+                </div>
+        );
 }


### PR DESCRIPTION
## Summary
- Restyle legal and consent pages with the ambassador gradient hero, card layout, and refreshed calls to action
- Refresh the paid games enablement flow with a split layout, hero banner, and support links
- Rebuild the advertising overview to highlight key features, placements, and pricing in the new marketing aesthetic
- Add a dedicated support center page that surfaces documentation links and contact options

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f53d2261048326b5e387acdc669c74