### PR TITLE
Add vendor management APIs and pages

### DIFF
--- a/app/api/vendors/[id]/route.ts
+++ b/app/api/vendors/[id]/route.ts
@@ -1,0 +1,126 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { ObjectId } from "mongodb";
+
+import {
+  deleteVendor,
+  getVendorById,
+  parseVendorPayload,
+  updateVendor,
+} from "@/lib/vendors";
+
+type RouteContext = {
+  params: { id: string };
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  try {
+    const { id } = context.params;
+
+    if (!ObjectId.isValid(id)) {
+      return NextResponse.json({ error: "Vendor not found" }, { status: 404 });
+    }
+
+    const vendor = await getVendorById(id);
+
+    if (!vendor) {
+      return NextResponse.json({ error: "Vendor not found" }, { status: 404 });
+    }
+
+    const cookieStore = await cookies();
+    const userId = cookieStore.get("userId")?.value;
+    const isAdmin = cookieStore.get("isAdmin")?.value === "true";
+
+    const isOwner = userId && vendor.ownerUserId === userId;
+    if (!vendor.isApproved && !isOwner && !isAdmin) {
+      return NextResponse.json({ error: "Vendor not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ vendor });
+  } catch (error) {
+    console.error("Failed to read vendor", error);
+    return NextResponse.json({ error: "Unable to read vendor" }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, context: RouteContext) {
+  try {
+    const { id } = context.params;
+
+    if (!ObjectId.isValid(id)) {
+      return NextResponse.json({ error: "Vendor not found" }, { status: 404 });
+    }
+
+    const existingVendor = await getVendorById(id);
+    if (!existingVendor) {
+      return NextResponse.json({ error: "Vendor not found" }, { status: 404 });
+    }
+
+    const cookieStore = await cookies();
+    const userId = cookieStore.get("userId")?.value;
+    const isAdmin = cookieStore.get("isAdmin")?.value === "true";
+
+    if (!userId) {
+      return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+    }
+
+    const isOwner = existingVendor.ownerUserId === userId;
+    if (!isOwner && !isAdmin) {
+      return NextResponse.json({ error: "Not authorized" }, { status: 403 });
+    }
+
+    const payload = await request.json();
+    const vendorData = parseVendorPayload(payload, { allowApprovalFields: isAdmin });
+
+    const updatedVendor = await updateVendor(id, vendorData, { allowApprovalFields: isAdmin });
+
+    if (!updatedVendor) {
+      return NextResponse.json({ error: "Vendor not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ vendor: updatedVendor });
+  } catch (error) {
+    console.error("Failed to update vendor", error);
+    const message = error instanceof Error ? error.message : "Unable to update vendor";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_request: Request, context: RouteContext) {
+  try {
+    const { id } = context.params;
+
+    if (!ObjectId.isValid(id)) {
+      return NextResponse.json({ error: "Vendor not found" }, { status: 404 });
+    }
+
+    const existingVendor = await getVendorById(id);
+    if (!existingVendor) {
+      return NextResponse.json({ error: "Vendor not found" }, { status: 404 });
+    }
+
+    const cookieStore = await cookies();
+    const userId = cookieStore.get("userId")?.value;
+    const isAdmin = cookieStore.get("isAdmin")?.value === "true";
+
+    if (!userId) {
+      return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+    }
+
+    const isOwner = existingVendor.ownerUserId === userId;
+    if (!isOwner && !isAdmin) {
+      return NextResponse.json({ error: "Not authorized" }, { status: 403 });
+    }
+
+    const deleted = await deleteVendor(id);
+
+    if (!deleted) {
+      return NextResponse.json({ error: "Vendor not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete vendor", error);
+    return NextResponse.json({ error: "Unable to delete vendor" }, { status: 500 });
+  }
+}

--- a/app/vendor/[id]/page.tsx
+++ b/app/vendor/[id]/page.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+
+import { DAYS_OF_WEEK } from "@/lib/constants";
+import { createDefaultHours, sortTimeSlots, type VendorResponse } from "@/lib/vendors";
+
+type AuthInfo = {
+  userId: string;
+  isAdmin: boolean;
+};
+
+type Params = {
+  id: string;
+};
+
+type HoursDisplay = Record<string, string[]>;
+
+const formatHours = (hours: HoursDisplay) =>
+  DAYS_OF_WEEK.map((day) => ({
+    day,
+    slots: hours[day] && hours[day].length > 0 ? hours[day] : [],
+  }));
+
+export default function VendorDetailsPage() {
+  const params = useParams<Params>();
+  const vendorId = params?.id;
+
+  const [vendor, setVendor] = useState<VendorResponse | null>(null);
+  const [hours, setHours] = useState<HoursDisplay>(() => createDefaultHours());
+  const [auth, setAuth] = useState<AuthInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const canEdit = Boolean(vendor && auth && (auth.isAdmin || auth.userId === vendor.ownerUserId));
+  const canModerate = Boolean(auth?.isAdmin);
+
+  useEffect(() => {
+    const fetchAuth = async () => {
+      try {
+        const response = await fetch("/api/auth/me");
+        if (!response.ok) {
+          setAuth(null);
+          return;
+        }
+
+        const data = await response.json();
+        setAuth({ userId: data.userId, isAdmin: data.isAdmin });
+      } catch (err) {
+        console.error(err);
+        setAuth(null);
+      }
+    };
+
+    fetchAuth();
+  }, []);
+
+  useEffect(() => {
+    if (!vendorId) return;
+
+    const fetchVendor = async () => {
+      setIsLoading(true);
+      setError(null);
+      setSuccess(null);
+
+      try {
+        const response = await fetch(`/api/vendors/${vendorId}`);
+        if (!response.ok) {
+          if (response.status === 404) {
+            setError("Vendor not found or unavailable.");
+          } else {
+            setError("Unable to load vendor details.");
+          }
+          setVendor(null);
+          return;
+        }
+
+        const data = await response.json();
+        const loadedVendor: VendorResponse | undefined = data.vendor;
+        if (loadedVendor) {
+          setVendor(loadedVendor);
+          const normalized = createDefaultHours();
+          Object.entries(loadedVendor.hoursOfOperation ?? {}).forEach(([day, slots]) => {
+            if (Array.isArray(slots)) {
+              normalized[day] = sortTimeSlots(slots);
+            }
+          });
+          setHours(normalized);
+        }
+      } catch (err) {
+        console.error(err);
+        setError("Unable to load vendor details.");
+        setVendor(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchVendor();
+  }, [vendorId]);
+
+  const handleModerationUpdate = async (updates: Partial<VendorResponse>) => {
+    if (!vendor || !canModerate) {
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    const payload = {
+      primaryImage: vendor.primaryImage,
+      images: vendor.images,
+      vendorName: vendor.vendorName,
+      description: vendor.description,
+      address1: vendor.address1,
+      address2: vendor.address2,
+      city: vendor.city,
+      state: vendor.state,
+      zip: vendor.zip,
+      phone: vendor.phone,
+      website: vendor.website,
+      hoursOfOperation: vendor.hoursOfOperation,
+      isApproved: updates.isApproved ?? vendor.isApproved,
+      isFeatured: updates.isFeatured ?? vendor.isFeatured,
+    };
+
+    try {
+      const response = await fetch(`/api/vendors/${vendor.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Unable to update vendor");
+      }
+
+      const data = await response.json();
+      const updated: VendorResponse | undefined = data.vendor;
+      if (updated) {
+        setVendor(updated);
+        const normalized = createDefaultHours();
+        Object.entries(updated.hoursOfOperation ?? {}).forEach(([day, slots]) => {
+          if (Array.isArray(slots)) {
+            normalized[day] = sortTimeSlots(slots);
+          }
+        });
+        setHours(normalized);
+        setSuccess("Vendor status updated.");
+      }
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "Unable to update vendor");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!vendor || !canEdit) {
+      return;
+    }
+
+    if (!window.confirm("Are you sure you want to delete this vendor profile?")) {
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const response = await fetch(`/api/vendors/${vendor.id}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Unable to delete vendor");
+      }
+
+      setVendor(null);
+      setSuccess("Vendor deleted.");
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "Unable to delete vendor");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (!vendorId) {
+    return (
+      <main className="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 text-slate-200">
+        Invalid vendor identifier.
+      </main>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <main className="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 text-slate-200">
+        Loading vendor details...
+      </main>
+    );
+  }
+
+  if (!vendor) {
+    return (
+      <main className="space-y-4">
+        <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 text-slate-200">
+          {error ?? "Vendor not found."}
+        </div>
+        <Link
+          href="/vendor"
+          className="inline-flex items-center rounded-lg border border-slate-700 px-4 py-2 text-sm text-slate-200 transition hover:border-slate-500"
+        >
+          Back to vendor management
+        </Link>
+      </main>
+    );
+  }
+
+  const displayHours = formatHours(hours);
+
+  return (
+    <main className="space-y-8">
+      <header className="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 shadow-lg shadow-slate-900/40">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-100">{vendor.vendorName}</h1>
+            <p className="mt-2 text-sm text-slate-400">Vendor application review</p>
+            <div className="mt-3 flex flex-wrap gap-3 text-sm text-slate-300">
+              <span>
+                Status:{" "}
+                {vendor.isApproved ? (
+                  <span className="text-emerald-400">Approved</span>
+                ) : (
+                  <span className="text-amber-400">Pending Review</span>
+                )}
+              </span>
+              {vendor.isFeatured ? <span className="text-sky-400">Featured Vendor</span> : null}
+            </div>
+          </div>
+          {canModerate ? (
+            <div className="flex flex-wrap gap-3 text-sm">
+              <button
+                type="button"
+                onClick={() => handleModerationUpdate({ isApproved: !vendor.isApproved })}
+                className="rounded-lg bg-gradient-to-r from-emerald-500 to-sky-500 px-4 py-2 font-semibold text-white shadow-lg shadow-slate-900/30 transition hover:from-emerald-400 hover:to-sky-400 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={isSaving}
+              >
+                {vendor.isApproved ? "Mark as Pending" : "Approve Vendor"}
+              </button>
+              <button
+                type="button"
+                onClick={() => handleModerationUpdate({ isFeatured: !vendor.isFeatured })}
+                className="rounded-lg border border-sky-500 px-4 py-2 font-medium text-sky-300 transition hover:bg-sky-500/10 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={isSaving}
+              >
+                {vendor.isFeatured ? "Remove Featured" : "Feature Vendor"}
+              </button>
+            </div>
+          ) : null}
+        </div>
+        <div className="mt-4 text-xs text-slate-500">
+          Vendor ID: {vendor.id}
+        </div>
+      </header>
+
+      {success ? <p className="text-emerald-400">{success}</p> : null}
+      {error ? <p className="text-rose-400">{error}</p> : null}
+
+      <section className="grid gap-6 md:grid-cols-[2fr,1fr]">
+        <article className="space-y-6 rounded-2xl border border-slate-800 bg-slate-950/70 p-6 shadow-lg shadow-slate-900/40">
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold text-slate-100">Overview</h2>
+            <p className="text-sm leading-relaxed text-slate-300 whitespace-pre-line">
+              {vendor.description}
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold text-slate-100">Location</h2>
+            <p className="text-sm text-slate-300">
+              {vendor.address1}
+              {vendor.address2 ? <><br />{vendor.address2}</> : null}
+              <br />
+              {vendor.city}, {vendor.state} {vendor.zip}
+            </p>
+            <p className="text-sm text-slate-300">
+              {vendor.phone ? (
+                <span className="block">
+                  Phone:{" "}
+                  <a href={`tel:${vendor.phone}`} className="text-sky-400 hover:underline">
+                    {vendor.phone}
+                  </a>
+                </span>
+              ) : null}
+              {vendor.website ? (
+                <span className="block">
+                  Website:{" "}
+                  <a
+                    href={vendor.website}
+                    className="text-sky-400 hover:underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {vendor.website}
+                  </a>
+                </span>
+              ) : null}
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold text-slate-100">Hours of Operation</h2>
+            <dl className="space-y-2 text-sm text-slate-300">
+              {displayHours.map(({ day, slots }) => (
+                <div key={day} className="flex flex-wrap justify-between gap-2 border-b border-slate-800 pb-2 last:border-0">
+                  <dt className="font-medium text-slate-200">{day}</dt>
+                  <dd className="text-right text-slate-300">
+                    {slots.length > 0 ? slots.join(", ") : <span className="text-slate-500">Closed</span>}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </article>
+
+        <aside className="space-y-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-6 shadow-lg shadow-slate-900/40">
+          <div className="space-y-3">
+            <h2 className="text-lg font-semibold text-slate-100">Media</h2>
+            <div className="relative h-48 w-full overflow-hidden rounded-xl border border-slate-800 bg-slate-900">
+              {vendor.primaryImage ? (
+                <Image
+                  src={vendor.primaryImage}
+                  alt={`${vendor.vendorName} primary image`}
+                  fill
+                  className="object-cover"
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center text-sm text-slate-500">
+                  No primary image provided
+                </div>
+              )}
+            </div>
+            {vendor.images && vendor.images.length > 0 ? (
+              <ul className="space-y-2 text-sm">
+                {vendor.images.map((image) => (
+                  <li key={image}>
+                    <a
+                      href={image}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sky-400 hover:underline"
+                    >
+                      {image}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-slate-500">No additional images supplied.</p>
+            )}
+          </div>
+
+          <div className="space-y-2 text-sm text-slate-300">
+            <p>
+              Owner User ID:{" "}
+              <span className="text-slate-100">{vendor.ownerUserId}</span>
+            </p>
+            {canEdit ? (
+              <button
+                type="button"
+                onClick={handleDelete}
+                className="inline-flex items-center rounded-lg border border-rose-500 px-4 py-2 font-medium text-rose-300 transition hover:bg-rose-500/10 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={isSaving}
+              >
+                Delete Vendor
+              </button>
+            ) : null}
+            <Link
+              href="/vendor"
+              className="inline-flex items-center rounded-lg border border-slate-700 px-4 py-2 text-slate-200 transition hover:border-slate-500"
+            >
+              Manage vendor
+            </Link>
+          </div>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/app/vendor/page.tsx
+++ b/app/vendor/page.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+import { DAYS_OF_WEEK, TIME_SLOT_GROUPS, TIME_SLOTS } from "@/lib/constants";
+import { createDefaultHours, sortTimeSlots } from "@/lib/vendors";
+
+type VendorResponse = {
+  id: string;
+  primaryImage: string;
+  images: string[];
+  vendorName: string;
+  description: string;
+  address1: string;
+  address2?: string;
+  city: string;
+  state: string;
+  zip: string;
+  phone?: string;
+  website?: string;
+  hoursOfOperation: Record<string, string[]>;
+  ownerUserId: string;
+  isApproved: boolean;
+  isFeatured: boolean;
+};
+
+const tagButtonClasses = (active: boolean) => {
+  const base = "rounded-full border px-3 py-1.5 text-sm transition";
+  if (active) {
+    return `${base} border-sky-400 bg-sky-500/20 text-sky-100`;
+  }
+  return `${base} border-slate-700 bg-slate-900 text-slate-200 hover:border-slate-500`;
+};
+
+const splitImagesInput = (value: string) =>
+  value
+    .split(/\r?\n|,/) // Allow comma or newline separated entries
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+export default function VendorManagementPage() {
+  const [vendorId, setVendorId] = useState<string | null>(null);
+  const [primaryImage, setPrimaryImage] = useState("");
+  const [imagesInput, setImagesInput] = useState("");
+  const [vendorName, setVendorName] = useState("");
+  const [description, setDescription] = useState("");
+  const [address1, setAddress1] = useState("");
+  const [address2, setAddress2] = useState("");
+  const [city, setCity] = useState("");
+  const [state, setState] = useState("");
+  const [zip, setZip] = useState("");
+  const [phone, setPhone] = useState("");
+  const [website, setWebsite] = useState("");
+  const [hours, setHours] = useState<Record<string, string[]>>(() => createDefaultHours());
+  const [lastClickedSlot, setLastClickedSlot] = useState<Record<string, string>>({});
+  const [isApproved, setIsApproved] = useState(false);
+  const [isFeatured, setIsFeatured] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteMessage, setDeleteMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchVendor = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await fetch("/api/vendors?owner=me");
+        if (!response.ok) {
+          if (response.status === 401) {
+            setError("You must be signed in to manage a vendor profile.");
+          } else {
+            setError("Unable to load vendor information.");
+          }
+          return;
+        }
+
+        const data = await response.json();
+        const vendor: VendorResponse | undefined = data.vendors?.[0];
+
+        if (vendor) {
+          setVendorId(vendor.id);
+          setPrimaryImage(vendor.primaryImage || "");
+          setImagesInput(vendor.images?.join("\n") ?? "");
+          setVendorName(vendor.vendorName || "");
+          setDescription(vendor.description || "");
+          setAddress1(vendor.address1 || "");
+          setAddress2(vendor.address2 || "");
+          setCity(vendor.city || "");
+          setState(vendor.state || "");
+          setZip(vendor.zip || "");
+          setPhone(vendor.phone || "");
+          setWebsite(vendor.website || "");
+
+          const normalizedHours = createDefaultHours();
+          Object.entries(vendor.hoursOfOperation ?? {}).forEach(([day, slots]) => {
+            if (Array.isArray(slots)) {
+              normalizedHours[day] = sortTimeSlots(slots);
+            }
+          });
+          setHours(normalizedHours);
+
+          setIsApproved(vendor.isApproved);
+          setIsFeatured(vendor.isFeatured);
+        }
+      } catch (err) {
+        console.error(err);
+        setError("Unable to load vendor information.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchVendor();
+  }, []);
+
+  const totalSelectedHours = useMemo(
+    () => DAYS_OF_WEEK.reduce((sum, day) => sum + (hours[day]?.length ?? 0), 0),
+    [hours]
+  );
+
+  const toggleHour = (day: string, slot: string, shiftKey: boolean) => {
+    setHours((prev) => {
+      const daySlots = prev[day] ?? [];
+
+      if (shiftKey && lastClickedSlot[day]) {
+        const startIdx = TIME_SLOTS.indexOf(lastClickedSlot[day]);
+        const endIdx = TIME_SLOTS.indexOf(slot);
+
+        if (startIdx !== -1 && endIdx !== -1) {
+          const [minIdx, maxIdx] = [Math.min(startIdx, endIdx), Math.max(startIdx, endIdx)];
+          const rangeSlots = TIME_SLOTS.slice(minIdx, maxIdx + 1);
+          const allSelected = rangeSlots.every((rangeSlot) => daySlots.includes(rangeSlot));
+
+          const updatedSlots = allSelected
+            ? daySlots.filter((item) => !rangeSlots.includes(item))
+            : sortTimeSlots([...daySlots, ...rangeSlots]);
+
+          return { ...prev, [day]: updatedSlots };
+        }
+      }
+
+      const exists = daySlots.includes(slot);
+      const updatedSlots = exists
+        ? daySlots.filter((item) => item !== slot)
+        : sortTimeSlots([...daySlots, slot]);
+
+      setLastClickedSlot((current) => ({ ...current, [day]: slot }));
+
+      return { ...prev, [day]: updatedSlots };
+    });
+  };
+
+  const resetForm = () => {
+    setVendorId(null);
+    setPrimaryImage("");
+    setImagesInput("");
+    setVendorName("");
+    setDescription("");
+    setAddress1("");
+    setAddress2("");
+    setCity("");
+    setState("");
+    setZip("");
+    setPhone("");
+    setWebsite("");
+    setHours(createDefaultHours());
+    setIsApproved(false);
+    setIsFeatured(false);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSaving(true);
+    setSaveSuccess(false);
+    setError(null);
+    setDeleteMessage(null);
+
+    const payload = {
+      primaryImage,
+      images: splitImagesInput(imagesInput),
+      vendorName,
+      description,
+      address1,
+      address2,
+      city,
+      state,
+      zip,
+      phone,
+      website,
+      hoursOfOperation: hours,
+    };
+
+    try {
+      const endpoint = vendorId ? `/api/vendors/${vendorId}` : "/api/vendors";
+      const method = vendorId ? "PUT" : "POST";
+
+      const response = await fetch(endpoint, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Unable to save vendor");
+      }
+
+      const data = await response.json();
+      const vendor: VendorResponse | undefined = data.vendor;
+
+      if (vendor) {
+        setVendorId(vendor.id);
+        setIsApproved(vendor.isApproved);
+        setIsFeatured(vendor.isFeatured);
+      }
+
+      setSaveSuccess(true);
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "Unable to save vendor");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!vendorId) return;
+    if (!window.confirm("Are you sure you want to delete this vendor profile?")) {
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    setDeleteMessage(null);
+
+    try {
+      const response = await fetch(`/api/vendors/${vendorId}`, { method: "DELETE" });
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Unable to delete vendor");
+      }
+
+      resetForm();
+      setDeleteMessage("Vendor profile deleted.");
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "Unable to delete vendor");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <main className="space-y-8">
+      <header className="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 shadow-lg shadow-slate-900/40">
+        <h1 className="text-2xl font-semibold text-slate-100">Vendor Application</h1>
+        <p className="mt-2 text-sm text-slate-400">
+          Submit your vendor details for review. Once approved by an administrator, your profile will
+          appear in public listings. You can update your information at any time.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3 text-sm text-slate-300">
+          <span>
+            Status: {isApproved ? (
+              <span className="text-emerald-400">Approved</span>
+            ) : (
+              <span className="text-amber-400">Pending Review</span>
+            )}
+          </span>
+          {isFeatured ? <span className="text-sky-400">Featured Vendor</span> : null}
+        </div>
+        {vendorId ? (
+          <p className="mt-2 text-xs text-slate-500">
+            Shareable link:{" "}
+            <Link href={`/vendor/${vendorId}`} className="text-sky-400 hover:underline">
+              /vendor/{vendorId}
+            </Link>
+          </p>
+        ) : null}
+      </header>
+
+      {isLoading ? (
+        <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 text-slate-300">
+          Loading vendor details...
+        </div>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-8 rounded-2xl border border-slate-800 bg-slate-950/70 p-6 shadow-lg shadow-slate-900/40"
+        >
+          <section className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-slate-200">Vendor Name</label>
+              <input
+                type="text"
+                value={vendorName}
+                onChange={(event) => setVendorName(event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-200">Primary Image URL</label>
+              <input
+                type="url"
+                value={primaryImage}
+                onChange={(event) => setPrimaryImage(event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                placeholder="https://example.com/primary-image.jpg"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-200">Additional Image URLs</label>
+              <textarea
+                value={imagesInput}
+                onChange={(event) => setImagesInput(event.target.value)}
+                className="mt-1 h-24 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                placeholder="One URL per line or comma separated"
+              />
+              <p className="mt-1 text-xs text-slate-500">
+                Provide any additional gallery images. Leave blank if you do not have extra images.
+              </p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-200">Website</label>
+              <input
+                type="url"
+                value={website}
+                onChange={(event) => setWebsite(event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                placeholder="https://your-site.example"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-200">Phone</label>
+              <input
+                type="tel"
+                value={phone}
+                onChange={(event) => setPhone(event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                placeholder="(555) 123-4567"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-200">Description</label>
+              <textarea
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                className="mt-1 h-32 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                placeholder="Tell us about your store, offerings, or services."
+                required
+              />
+            </div>
+          </section>
+
+          <section className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-slate-200">Address Line 1</label>
+              <input
+                type="text"
+                value={address1}
+                onChange={(event) => setAddress1(event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-200">Address Line 2</label>
+              <input
+                type="text"
+                value={address2}
+                onChange={(event) => setAddress2(event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                placeholder="Suite, Unit, etc."
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-200">City</label>
+              <input
+                type="text"
+                value={city}
+                onChange={(event) => setCity(event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                required
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-slate-200">State / Province</label>
+                <input
+                  type="text"
+                  value={state}
+                  onChange={(event) => setState(event.target.value)}
+                  className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-200">ZIP / Postal Code</label>
+                <input
+                  type="text"
+                  value={zip}
+                  onChange={(event) => setZip(event.target.value)}
+                  className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                  required
+                />
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-100">Hours of Operation</h2>
+                <p className="text-sm text-slate-400">
+                  Select the hours your business is open. Use Shift + Click to select ranges quickly.
+                </p>
+              </div>
+              <span className="text-xs text-slate-500">{totalSelectedHours} hour(s) selected</span>
+            </div>
+
+            <div className="space-y-5">
+              {DAYS_OF_WEEK.map((day) => (
+                <div key={day} className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-medium text-slate-200">{day}</h3>
+                    <span className="text-xs text-slate-500">{hours[day]?.length ?? 0} hour(s)</span>
+                  </div>
+                  <div className="space-y-3">
+                    {TIME_SLOT_GROUPS.map((group) => (
+                      <div key={group.label}>
+                        <div className="mb-2 text-xs font-semibold text-slate-500">{group.label}</div>
+                        <div className="flex flex-wrap gap-2">
+                          {group.slots.map((slot) => {
+                            const active = hours[day]?.includes(slot) ?? false;
+                            return (
+                              <button
+                                key={slot}
+                                type="button"
+                                onClick={(event) => toggleHour(day, slot, event.shiftKey)}
+                                className={tagButtonClasses(active)}
+                              >
+                                {slot}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <div className="space-y-3 text-sm">
+            <button
+              type="submit"
+              className="rounded-lg bg-gradient-to-r from-sky-500 via-indigo-500 to-purple-500 px-4 py-2 font-semibold text-white shadow-lg shadow-slate-900/40 transition hover:from-sky-400 hover:via-indigo-400 hover:to-purple-400 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isSaving || isLoading}
+            >
+              {isSaving ? "Saving..." : vendorId ? "Update Vendor" : "Submit Application"}
+            </button>
+            {vendorId ? (
+              <button
+                type="button"
+                onClick={handleDelete}
+                className="inline-flex items-center rounded-lg border border-rose-500 px-4 py-2 font-medium text-rose-300 transition hover:bg-rose-500/10"
+                disabled={isSaving}
+              >
+                Delete Vendor
+              </button>
+            ) : null}
+            {saveSuccess ? (
+              <p className="text-emerald-400">Vendor information saved successfully.</p>
+            ) : null}
+            {deleteMessage ? <p className="text-amber-400">{deleteMessage}</p> : null}
+            {error ? <p className="text-rose-400">{error}</p> : null}
+          </div>
+        </form>
+      )}
+    </main>
+  );
+}

--- a/lib/vendors.ts
+++ b/lib/vendors.ts
@@ -1,0 +1,285 @@
+import { ObjectId, type OptionalId } from "mongodb";
+import { getDb } from "@/lib/mongodb";
+import { DAYS_OF_WEEK, TIME_SLOTS } from "@/lib/constants";
+
+export type VendorHours = Record<string, string[]>;
+
+export type VendorDocument = {
+  _id?: ObjectId;
+  primaryImage: string;
+  images: string[];
+  vendorName: string;
+  description: string;
+  address1: string;
+  address2?: string;
+  city: string;
+  state: string;
+  zip: string;
+  phone?: string;
+  website?: string;
+  hoursOfOperation: VendorHours;
+  ownerUserId: string;
+  isApproved: boolean;
+  isFeatured: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type VendorResponse = VendorDocument & { id: string };
+
+export type VendorPayload = {
+  primaryImage: string;
+  images: string[];
+  vendorName: string;
+  description: string;
+  address1: string;
+  address2?: string;
+  city: string;
+  state: string;
+  zip: string;
+  phone?: string;
+  website?: string;
+  hoursOfOperation: VendorHours;
+  isApproved?: boolean;
+  isFeatured?: boolean;
+};
+
+const VALID_DAYS = new Set(DAYS_OF_WEEK);
+const VALID_TIME_SLOTS = new Set(TIME_SLOTS);
+
+export const createDefaultHours = (): VendorHours =>
+  DAYS_OF_WEEK.reduce((acc, day) => {
+    acc[day] = [];
+    return acc;
+  }, {} as VendorHours);
+
+export function sortTimeSlots(slots: string[]): string[] {
+  return Array.from(new Set(slots))
+    .filter((slot) => VALID_TIME_SLOTS.has(slot))
+    .sort((a, b) => TIME_SLOTS.indexOf(a) - TIME_SLOTS.indexOf(b));
+}
+
+export function normalizeHours(hours: VendorHours | undefined): VendorHours {
+  const normalized = createDefaultHours();
+
+  if (!hours || typeof hours !== "object") {
+    return normalized;
+  }
+
+  Object.entries(hours).forEach(([day, slots]) => {
+    if (VALID_DAYS.has(day) && Array.isArray(slots)) {
+      normalized[day] = sortTimeSlots(slots.filter((slot): slot is string => typeof slot === "string"));
+    }
+  });
+
+  return normalized;
+}
+
+function ensureString(value: unknown, field: string, { optional = false, allowEmpty = false } = {}): string | undefined {
+  if (value === undefined || value === null) {
+    if (optional) {
+      return undefined;
+    }
+    throw new Error(`${field} is required`);
+  }
+
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a string`);
+  }
+
+  const trimmed = value.trim();
+
+  if (!allowEmpty && trimmed.length === 0) {
+    if (optional) {
+      return undefined;
+    }
+    throw new Error(`${field} cannot be empty`);
+  }
+
+  return trimmed;
+}
+
+function ensureStringArray(value: unknown, field: string): string[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new Error(`${field} must be an array of strings`);
+  }
+
+  const strings = value
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+  return Array.from(new Set(strings));
+}
+
+export function parseVendorPayload(
+  payload: unknown,
+  options: { allowApprovalFields?: boolean } = {}
+): VendorPayload {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Invalid vendor payload");
+  }
+
+  const {
+    primaryImage,
+    images,
+    vendorName,
+    description,
+    address1,
+    address2,
+    city,
+    state,
+    zip,
+    phone,
+    website,
+    hoursOfOperation,
+    isApproved,
+    isFeatured,
+  } = payload as Partial<VendorPayload>;
+
+  const normalized: VendorPayload = {
+    primaryImage: ensureString(primaryImage, "primaryImage"),
+    images: ensureStringArray(images, "images"),
+    vendorName: ensureString(vendorName, "vendorName"),
+    description: ensureString(description, "description"),
+    address1: ensureString(address1, "address1"),
+    address2: ensureString(address2, "address2", { optional: true, allowEmpty: true }),
+    city: ensureString(city, "city"),
+    state: ensureString(state, "state"),
+    zip: ensureString(zip, "zip"),
+    phone: ensureString(phone, "phone", { optional: true, allowEmpty: true }),
+    website: ensureString(website, "website", { optional: true, allowEmpty: true }),
+    hoursOfOperation: normalizeHours(hoursOfOperation),
+  };
+
+  if (options.allowApprovalFields) {
+    const rawPayload = payload as Record<string, unknown>;
+    if (Object.prototype.hasOwnProperty.call(rawPayload, "isApproved")) {
+      normalized.isApproved = Boolean(isApproved);
+    }
+    if (Object.prototype.hasOwnProperty.call(rawPayload, "isFeatured")) {
+      normalized.isFeatured = Boolean(isFeatured);
+    }
+  }
+
+  return normalized;
+}
+
+function toVendorResponse(document: VendorDocument): VendorResponse {
+  const { _id, ...rest } = document;
+  return {
+    ...rest,
+    id: _id?.toString() ?? "",
+  } as VendorResponse;
+}
+
+export async function listVendors(options: {
+  includeUnapproved?: boolean;
+  ownerUserId?: string;
+} = {}): Promise<VendorResponse[]> {
+  const db = await getDb();
+  const collection = db.collection<VendorDocument>("vendors");
+
+  const filter: Record<string, unknown> = {};
+  if (options.ownerUserId) {
+    filter.ownerUserId = options.ownerUserId;
+  } else if (!options.includeUnapproved) {
+    filter.isApproved = true;
+  }
+
+  const vendors = await collection
+    .find(filter)
+    .sort({ isFeatured: -1, vendorName: 1 })
+    .toArray();
+
+  return vendors.map(toVendorResponse);
+}
+
+export async function getVendorById(id: string): Promise<VendorResponse | null> {
+  if (!ObjectId.isValid(id)) {
+    return null;
+  }
+
+  const db = await getDb();
+  const collection = db.collection<VendorDocument>("vendors");
+
+  const objectId = new ObjectId(id);
+  const vendor = await collection.findOne({ _id: objectId });
+
+  if (!vendor) {
+    return null;
+  }
+
+  return toVendorResponse(vendor);
+}
+
+export async function createVendor(ownerUserId: string, payload: VendorPayload): Promise<VendorResponse | null> {
+  const db = await getDb();
+  const collection = db.collection<VendorDocument>("vendors");
+
+  const now = new Date();
+  const document: OptionalId<VendorDocument> = {
+    ...payload,
+    ownerUserId,
+    isApproved: payload.isApproved ?? false,
+    isFeatured: payload.isFeatured ?? false,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const { insertedId } = await collection.insertOne(document);
+
+  return getVendorById(insertedId.toString());
+}
+
+export async function updateVendor(
+  id: string,
+  payload: VendorPayload,
+  options: { allowApprovalFields?: boolean } = {}
+): Promise<VendorResponse | null> {
+  if (!ObjectId.isValid(id)) {
+    return null;
+  }
+
+  const db = await getDb();
+  const collection = db.collection<VendorDocument>("vendors");
+
+  const objectId = new ObjectId(id);
+  const update: Partial<VendorDocument> = {
+    ...payload,
+    updatedAt: new Date(),
+  };
+
+  if (!options.allowApprovalFields) {
+    delete update.isApproved;
+    delete update.isFeatured;
+  } else {
+    update.isApproved = payload.isApproved ?? false;
+    update.isFeatured = payload.isFeatured ?? false;
+  }
+
+  const result = await collection.updateOne({ _id: objectId }, { $set: update });
+
+  if (result.matchedCount === 0) {
+    return null;
+  }
+
+  return getVendorById(id);
+}
+
+export async function deleteVendor(id: string): Promise<boolean> {
+  if (!ObjectId.isValid(id)) {
+    return false;
+  }
+
+  const db = await getDb();
+  const collection = db.collection<VendorDocument>("vendors");
+
+  const objectId = new ObjectId(id);
+  const result = await collection.deleteOne({ _id: objectId });
+
+  return result.deletedCount > 0;
+}


### PR DESCRIPTION
## Summary
- add Mongo-backed vendor data helpers for validation and normalized hours of operation
- expose vendor CRUD and moderation endpoints for owners and admins
- build vendor application form and admin review page with approval controls

## Testing
- npm run lint *(fails: existing lint errors in scripts/validate-stripe.js and unrelated warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68f56c053f98832686ec85455b93c669